### PR TITLE
Check if data is FormData and don't treat like JSON if it is.

### DIFF
--- a/addon/services/ajax.js
+++ b/addon/services/ajax.js
@@ -128,7 +128,14 @@ export default Ember.Service.extend({
     hash.dataType = 'json';
     hash.context = this;
 
-    if (hash.data && type !== 'GET') {
+    var formData;
+    if (hash.data && hash.data.constructor) {
+      if(hash.data.constructor.name === 'FormData') {
+        formData = true;
+      }
+    }
+
+    if (hash.data && type !== 'GET' && !formData) {
       hash.contentType = 'application/json; charset=utf-8';
       hash.data = JSON.stringify(hash.data);
     }


### PR DESCRIPTION
Note: I don't expect to get merged this as-is. I'm putting it here as a 'strawman' to even see if anybody thinks non-json content types should be supported and how that support should be included. Some options might include:

1. Only check if data is FormData, otherwise treat as JSON (current state of my fork -- Band-Aid for my immediate problem).
2. Allow user to opt-out of json with an additional param to ajax() call, otherwise treat as JSON.
3. Check if data is valid JSON and handle it as such only if it is.
4. Check for existing options such as 'dataType' and/or 'contentType' and make assumptions from there.