### PR TITLE
[ENHANCEMENT] Don't make assumptions about dataType and payload.

### DIFF
--- a/addon/services/ajax.js
+++ b/addon/services/ajax.js
@@ -125,13 +125,8 @@ export default Ember.Service.extend({
     var hash = options || {};
     hash.url = url;
     hash.type = type;
-    hash.dataType = 'json';
+    hash.dataType = hash.dataType || 'json';
     hash.context = this;
-
-    if (hash.data && type !== 'GET') {
-      hash.contentType = 'application/json; charset=utf-8';
-      hash.data = JSON.stringify(hash.data);
-    }
 
     var headers = get(this, 'headers');
     if (headers !== undefined) {

--- a/tests/unit/services/ajax-test.js
+++ b/tests/unit/services/ajax-test.js
@@ -46,7 +46,7 @@ test('options() headers are set', function(assert){
   assert.deepEqual(receivedHeaders, [['Content-Type', 'application/json'], ['Other-key', 'Other Value']], 'headers assigned');
 });
 
-test("options() do not serializes data when GET", function(assert) {
+test("options() sets raw data", function(assert) {
   service = Service.create();
 
   var url = 'example.com';
@@ -64,12 +64,20 @@ test("options() do not serializes data when GET", function(assert) {
   });
 });
 
-test("options() serializes data when not GET", function(assert) {
+test("options() sets options correctly", function(assert) {
   service = Service.create();
 
-  var url = 'example.com';
+  var url  = 'example.com';
   var type = 'POST';
-  var ajaxOptions = service.options(url, type, { data: { key: 'value' } });
+  var data = JSON.stringify({ key: 'value' });
+  var ajaxOptions = service.options(
+    url,
+    type,
+    {
+      data: data,
+      contentType: "application/json; charset=utf-8"
+    }
+  );
 
   assert.deepEqual(ajaxOptions, {
     contentType: "application/json; charset=utf-8",


### PR DESCRIPTION
Since the final goal of this is to become a service for making **AJAX** request, it would be a good idea not to make many assumptions about such request, **AJAX** does not necessarily mean  **json**. 

I'd like to propose we just expose the basic interface for **jQuery.ajax** without trying to be too smart about it. With this we also address issues like #2.

Also what about changing the the args of `service.request` to be ONLY `url` and `options`, I think this provides better ergonomics that the current implementation, for example if I want to do a get with query params I'd have to do something like `service.request(url, 'GET', {data: {foo: true}}` this could be reduce to `service.request(url, {data: {foo: true}}` since `GET` tends to be the default, and then if I need a different request type, then I could just specify that in the options (like `$.ajax`) 
