### PR TITLE
Add HTTP-verb methods on ajax service

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ export default Ember.Route.extend({
 ### HTTP-verbed methods
 
 Can skip setting the `method` or `type` keys in your `options` object when calling `request(url, options)` by
-instead calling `post(url, options)`, `put(url, options)` or `delete(url, options)`.
+instead calling `post(url, options)`, `put(url, options)` or `del(url, options)`.
 
 ```js
 post('/posts', { data: { title: 'Ember' } })  // Makes a POST request to /posts
 put('/posts/1', { data: { title: 'Ember' } }) // Makes a PUT request to /posts/1
-delete('/posts/1', { })                       // Makes a DELETE request to /posts/1
+del('/posts/1', { })                          // Makes a DELETE request to /posts/1
 ```
 
 ### Custom Request Headers

--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ export default Ember.Route.extend({
 
 ## Ajax Service
 
+### HTTP-verbed methods
+
+Can skip setting the `method` or `type` keys in your `options` object when calling `request(url, options)` by
+instead calling `post(url, options)`, `put(url, options)` or `delete(url, options)`.
+
+```js
+post('/posts', { data: { title: 'Ember' } })  // Makes a POST request to /posts
+put('/posts/1', { data: { title: 'Ember' } }) // Makes a PUT request to /posts/1
+delete('/posts/1', { })                       // Makes a DELETE request to /posts/1
+```
+
 ### Custom Request Headers
 
 `ember-ajax` allows you to specify headers to be used with a request. This is

--- a/addon/services/ajax.js
+++ b/addon/services/ajax.js
@@ -133,6 +133,29 @@ export default Ember.Service.extend({
     }, `ember-ajax: ${hash.type} to ${url}`);
   },
 
+  // calls `request()` but forces `options.type` to `POST`
+  post(url, options) {
+    return this.request(url, this._addTypeToOptionsFor(options, 'POST'));
+  },
+
+  // calls `request()` but forces `options.type` to `PUT`
+  put(url, options) {
+    return this.request(url, this._addTypeToOptionsFor(options, 'PUT'));
+  },
+
+  // calls `request()` but forces `options.type` to `DELETE`
+  del(url, options) {
+    return this.request(url, this._addTypeToOptionsFor(options, 'DELETE'));
+  },
+
+  // forcibly manipulates the options hash to include the HTTP method on the type key
+  _addTypeToOptionsFor(options, method) {
+    options = options || {};
+    delete options.type;
+    options.type = method;
+    return options;
+  },
+
   /**
     @method options
     @private

--- a/addon/services/ajax.js
+++ b/addon/services/ajax.js
@@ -151,7 +151,6 @@ export default Ember.Service.extend({
   // forcibly manipulates the options hash to include the HTTP method on the type key
   _addTypeToOptionsFor(options, method) {
     options = options || {};
-    delete options.type;
     options.type = method;
     return options;
   },

--- a/tests/unit/services/ajax-test.js
+++ b/tests/unit/services/ajax-test.js
@@ -152,9 +152,8 @@ test("post() promise label is correct", function(assert) {
   const postPromise = service.post(url, options);
   assert.equal(postPromise._label, 'ember-ajax: POST to /posts');
 
-  postPromise.then(function (response) {
-    assert.equal(response.post.title, title);
-    assert.equal(response.post.description, description);
+  return postPromise.then(function (response) {
+    assert.deepEqual(response.post, options.data.post);
   });
 });
 
@@ -177,10 +176,8 @@ test("put() promise label is correct", function(assert) {
   const putPromise = service.put(url, options);
   assert.equal(putPromise._label, 'ember-ajax: PUT to /posts/1');
 
-  putPromise.then(function (response) {
-    assert.equal(response.post.title, title);
-    assert.equal(response.post.description, description);
-    assert.equal(response.post.id, id);
+  return putPromise.then(function (response) {
+    assert.deepEqual(response.post, options.data.post);
   });
 });
 
@@ -195,8 +192,8 @@ test("del() promise label is correct", function(assert) {
   const delPromise = service.del(url);
   assert.equal(delPromise._label, 'ember-ajax: DELETE to /posts/1');
 
-  delPromise.then(function (response) {
-    assert.equal(response, {});
+  return delPromise.then(function (response) {
+    assert.deepEqual(response, {});
   });
 });
 

--- a/tests/unit/services/ajax-test.js
+++ b/tests/unit/services/ajax-test.js
@@ -115,8 +115,8 @@ test("options() type defaults to GET", function(assert) {
 
 test("request() promise label is correct", function(assert) {
   service = Service.create();
-  const url = '/posts';
-  const data = {
+  let url = '/posts';
+  let data = {
     type: 'POST',
     data: {
       post: { title: 'Title', description: 'Some description.' }
@@ -127,54 +127,77 @@ test("request() promise label is correct", function(assert) {
   server.get(url, () => serverResponse);
   server.post(url, () => serverResponse);
 
-  var getPromise = service.request(url);
+  const getPromise = service.request(url);
   assert.equal(getPromise._label, 'ember-ajax: GET to /posts');
 
-  var postPromise = service.request(url, data);
+  const postPromise = service.request(url, data);
   assert.equal(postPromise._label, 'ember-ajax: POST to /posts');
 });
 
 test("post() promise label is correct", function(assert) {
   service = Service.create();
-  const url = '/posts';
-  const options = {
+  let url = '/posts',
+    title = 'Title',
+    description = 'Some description.',
+    options = {
     data: {
-      post: { title: 'Title', description: 'Some description.' }
+      post: { title: title, description: description }
     }
   };
+
   const serverResponse = [200, { "Content-Type": "application/json" }, JSON.stringify(options.data)];
 
   server.post(url, () => serverResponse);
 
   const postPromise = service.post(url, options);
   assert.equal(postPromise._label, 'ember-ajax: POST to /posts');
+
+  postPromise.then(function (response) {
+    assert.equal(response.post.title, title);
+    assert.equal(response.post.description, description);
+  });
 });
 
 test("put() promise label is correct", function(assert) {
   service = Service.create();
-  const url = '/posts/1';
-  const options = {
+  let url = '/posts/1',
+    title = 'Title',
+    description = 'Some description.',
+    id = 1,
+    options = {
     data: {
-      post: { title: 'Title', description: 'Some description.' }
+      post: { id: id, title: title, description: description }
     }
   };
+
   const serverResponse = [200, { "Content-Type": "application/json" }, JSON.stringify(options.data)];
 
   server.put(url, () => serverResponse);
 
   const putPromise = service.put(url, options);
   assert.equal(putPromise._label, 'ember-ajax: PUT to /posts/1');
+
+  putPromise.then(function (response) {
+    assert.equal(response.post.title, title);
+    assert.equal(response.post.description, description);
+    assert.equal(response.post.id, id);
+  });
 });
 
 test("del() promise label is correct", function(assert) {
   service = Service.create();
-  const url = '/posts/1';
+  let url = '/posts/1';
+
   const serverResponse = [200, { "Content-Type": "application/json" }, JSON.stringify({})];
 
   server.delete(url, () => serverResponse);
 
   const delPromise = service.del(url);
   assert.equal(delPromise._label, 'ember-ajax: DELETE to /posts/1');
+
+  delPromise.then(function (response) {
+    assert.equal(response, {});
+  });
 });
 
 test("options() host is set on the url (url starting with `/`", function(assert) {

--- a/tests/unit/services/ajax-test.js
+++ b/tests/unit/services/ajax-test.js
@@ -134,6 +134,49 @@ test("request() promise label is correct", function(assert) {
   assert.equal(postPromise._label, 'ember-ajax: POST to /posts');
 });
 
+test("post() promise label is correct", function(assert) {
+  service = Service.create();
+  const url = '/posts';
+  const options = {
+    data: {
+      post: { title: 'Title', description: 'Some description.' }
+    }
+  };
+  const serverResponse = [200, { "Content-Type": "application/json" }, JSON.stringify(options.data)];
+
+  server.post(url, () => serverResponse);
+
+  const postPromise = service.post(url, options);
+  assert.equal(postPromise._label, 'ember-ajax: POST to /posts');
+});
+
+test("put() promise label is correct", function(assert) {
+  service = Service.create();
+  const url = '/posts/1';
+  const options = {
+    data: {
+      post: { title: 'Title', description: 'Some description.' }
+    }
+  };
+  const serverResponse = [200, { "Content-Type": "application/json" }, JSON.stringify(options.data)];
+
+  server.put(url, () => serverResponse);
+
+  const putPromise = service.put(url, options);
+  assert.equal(putPromise._label, 'ember-ajax: PUT to /posts/1');
+});
+
+test("del() promise label is correct", function(assert) {
+  service = Service.create();
+  const url = '/posts/1';
+  const serverResponse = [200, { "Content-Type": "application/json" }, JSON.stringify({})];
+
+  server.delete(url, () => serverResponse);
+
+  const delPromise = service.del(url);
+  assert.equal(delPromise._label, 'ember-ajax: DELETE to /posts/1');
+});
+
 test("options() host is set on the url (url starting with `/`", function(assert) {
   service = Service.create({ host: 'https://discuss.emberjs.com' });
 


### PR DESCRIPTION
* `post(url, options)` - sets options.type to POST
* `del(url, options)` - sets options.type to DELETE
* `put(url, options)` - sets options.type to PUT

Added documentation and a few comments in code