### PR TITLE
Use najax when DOM is not present

### DIFF
--- a/addon/services/ajax.js
+++ b/addon/services/ajax.js
@@ -73,6 +73,7 @@ const {
   ```
 
 **/
+
 export default Ember.Service.extend({
 
   request(url, options) {
@@ -129,7 +130,11 @@ export default Ember.Service.extend({
          reject(error);
       };
 
-      Ember.$.ajax(hash);
+      if (typeof najax === 'undefined') {
+        Ember.$.ajax(hash);
+      } else {
+        najax(hash); // jshint ignore:line
+      }
     }, `ember-ajax: ${hash.type} to ${url}`);
   },
 


### PR DESCRIPTION
When the DOM isn't specified we can assume that this service is being
used within the context of Fastboot.  Unfortunately, Ember.$.ajax won't
do the correct thing.  Fastboot has created a service:

https://github.com/tildeio/ember-cli-fastboot/blob/master/app/initializers/server/ajax.js

That implements adapter#ajax in the context of node using `najax`

This checks to see if the DOM is present and if so behaves as it did
before, however when DOM isn't present it will assume Fastboot has
loaded najax and will call it passsing in the same `hash` parameters