### PR TITLE
Add error types for 400 and 5XX errors

### DIFF
--- a/addon/errors.js
+++ b/addon/errors.js
@@ -37,3 +37,15 @@ export function ForbiddenError(errors) {
 }
 
 ForbiddenError.prototype = Object.create(AjaxError.prototype);
+
+export function BadRequestError(errors) {
+  AjaxError.call(this, errors, 'Request was formatted incorrectly.');
+}
+
+BadRequestError.prototype = Object.create(AjaxError.prototype);
+
+export function ServerError(errors) {
+  AjaxError.call(this, errors, 'Request was rejected due to server error');
+}
+
+ServerError.prototype = Object.create(AjaxError.prototype);

--- a/addon/services/ajax.js
+++ b/addon/services/ajax.js
@@ -4,7 +4,9 @@ import {
   AjaxError,
   UnauthorizedError,
   InvalidError,
-  ForbiddenError
+  ForbiddenError,
+  BadRequestError,
+  ServerError
 } from '../errors';
 import parseResponseHeaders from '../utils/parse-response-headers';
 
@@ -225,6 +227,7 @@ export default Ember.Service.extend({
    @return {Object | DS.AdapterError} response
  */
  handleResponse(status, headers, payload) {
+   payload = payload || {};
    if (this.isSuccess(status, headers, payload)) {
      return payload;
    } else if (this.isUnauthorized(status, headers, payload)) {
@@ -233,6 +236,10 @@ export default Ember.Service.extend({
      return new ForbiddenError(payload.errors);
    } else if (this.isInvalid(status, headers, payload)) {
      return new InvalidError(payload.errors);
+   } else if (this.isBadRequest(status)) {
+     return new BadRequestError(payload.errors);
+   } else if (this.isServerError(status)) {
+     return new ServerError(payload.errors);
    }
 
    let errors = this.normalizeErrorResponse(status, headers, payload);
@@ -276,7 +283,25 @@ export default Ember.Service.extend({
     @return {Boolean}
   */
   isInvalid(status/*, headers, payload */) {
-  return status === 422;
+    return status === 422;
+  },
+
+  /**
+    @method isBadRequest
+    @param  {Number} status
+    @return {Boolean}
+  */
+  isBadRequest(status) {
+    return status === 400;
+  },
+
+  /**
+     @method isServerError
+     @param {Number} status
+     @return {Boolean}
+   */
+  isServerError(status) {
+    return status >= 500 && status < 600;
   },
 
    /**

--- a/tests/unit/errors-test.js
+++ b/tests/unit/errors-test.js
@@ -8,7 +8,9 @@ import {
   AjaxError,
   InvalidError,
   UnauthorizedError,
-  ForbiddenError
+  ForbiddenError,
+  BadRequestError,
+  ServerError
 } from 'ember-ajax/errors';
 
 module("unit/errors-test - AjaxError");
@@ -35,4 +37,16 @@ test("ForbiddenError", function(assert){
   var error = new ForbiddenError();
   assert.ok(error instanceof Error);
   assert.ok(error instanceof ForbiddenError);
+});
+
+test("BadRequestError", function(assert) {
+  var error = new BadRequestError();
+  assert.ok(error instanceof Error);
+  assert.ok(error instanceof BadRequestError);
+});
+
+test("ServerError", function(assert) {
+  var error = new ServerError();
+  assert.ok(error instanceof Error);
+  assert.ok(error instanceof ServerError);
 });

--- a/tests/unit/services/ajax-test.js
+++ b/tests/unit/services/ajax-test.js
@@ -8,7 +8,9 @@ import Service from 'ember-ajax/services/ajax';
 import {
   InvalidError,
   UnauthorizedError,
-  ForbiddenError
+  ForbiddenError,
+  BadRequestError,
+  ServerError
  } from 'ember-ajax/errors';
 
 import Pretender from 'pretender';
@@ -256,3 +258,7 @@ const errorHandlerTest = ( status, errorClass ) => {
 errorHandlerTest(401, UnauthorizedError);
 errorHandlerTest(403, ForbiddenError);
 errorHandlerTest(422, InvalidError);
+errorHandlerTest(400, BadRequestError);
+errorHandlerTest(500, ServerError);
+errorHandlerTest(502, ServerError);
+errorHandlerTest(510, ServerError);


### PR DESCRIPTION
Adds two new errors types, `BadRequestError` and `ServerError`, which correspond to `400` and `5XX` errors, respectively.

Closes #36