### PR TITLE
Make host option overridable

### DIFF
--- a/addon/ajax-request.js
+++ b/addon/ajax-request.js
@@ -118,7 +118,7 @@ export default class AjaxRequest {
    */
   options(url, options) {
     const hash = options || {};
-    hash.url = this._buildURL(url);
+    hash.url = this._buildURL(url, hash);
     hash.type = hash.type || 'GET';
     hash.dataType = hash.dataType || 'json';
     hash.context = this;
@@ -133,9 +133,9 @@ export default class AjaxRequest {
     return hash;
   }
 
-  _buildURL(url) {
-    const host = get(this, 'host');
-    if (isBlank(host)) {
+  _buildURL(url, options) {
+    const host = options.host || get(this, 'host');
+    if (isBlank(host) || host === '/') {
       return url;
     }
     const startsWith = String.prototype.startsWith || function(searchString, position) {

--- a/tests/unit/ajax-request-test.js
+++ b/tests/unit/ajax-request-test.js
@@ -215,7 +215,7 @@ test('del() promise label is correct', function(assert) {
   });
 });
 
-test('options() host is set on the url (url starting with `/`', function(assert) {
+test('options() host is set on the url (url starting with `/`)', function(assert) {
   class RequestWithHost extends AjaxRequest {
     get host() {
       return 'https://discuss.emberjs.com';
@@ -228,7 +228,7 @@ test('options() host is set on the url (url starting with `/`', function(assert)
   assert.equal(ajaxoptions.url, 'https://discuss.emberjs.com/users/me');
 });
 
-test('options() host is set on the url (url not starting with `/`', function(assert) {
+test('options() host is set on the url (url not starting with `/`)', function(assert) {
   class RequestWithHost extends AjaxRequest {
     get host() {
       return 'https://discuss.emberjs.com';
@@ -239,6 +239,20 @@ test('options() host is set on the url (url not starting with `/`', function(ass
   const ajaxoptions = service.options(url);
 
   assert.equal(ajaxoptions.url, 'https://discuss.emberjs.com/users/me');
+});
+
+test('options() host is overridable on a per-request basis', function(assert) {
+  class RequestWithHost extends AjaxRequest {
+    get host() {
+      return 'https://discuss.emberjs.com';
+    }
+  }
+  const service = new RequestWithHost();
+  const url = 'users/me';
+  const host = 'https://myurl.com';
+  const ajaxoptions = service.options(url, { host });
+
+  assert.equal(ajaxoptions.url, 'https://myurl.com/users/me');
 });
 
 const errorHandlerTest = (status, errorClass) => {


### PR DESCRIPTION
Updated version of #23 to match the new ES6 setup.  Adds tests.