### PR TITLE
Ability to  have an array of allowedHosts to set headers for.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ export default AjaxService.extend({
 });
 ```
 
-Headers by default are only passed if the hosts match, or the request is a relitive path.
+Headers by default are only passed if the hosts match, or the request is a relative path.
 You can overwrite this behavior by either passing a host in with the request, setting the
-host for the ajax service, or by setting an array of allowedHosts that can be either
-strings or regular expressions.
+host for the ajax service, or by setting an array of `allowedHosts` that can be either
+an array of strings or regexes.
 
 ```js
 // app/services/ajax.js

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ export default AjaxService.extend({
 
 Headers by default are only passed if the hosts match, or the request is a relative path.
 You can overwrite this behavior by either passing a host in with the request, setting the
-host for the ajax service, or by setting an array of `allowedHosts` that can be either
+host for the ajax service, or by setting an array of `trustedHosts` that can be either
 an array of strings or regexes.
 
 ```js
@@ -113,7 +113,7 @@ import Ember from 'ember';
 import AjaxService from 'ember-ajax/services/ajax';
 
 export default AjaxService.extend({
-  allowedHosts: [
+  trustedHosts: [
     /\.example\./,
     'foo.bar.com',
   ]

--- a/README.md
+++ b/README.md
@@ -101,6 +101,26 @@ export default AjaxService.extend({
 });
 ```
 
+Headers by default are only passed if the hosts match, or the request is a relitive path.
+You can overwrite this behavior by either passing a host in with the request, setting the
+host for the ajax service, or by setting an array of allowedHosts that can be either
+strings or regular expressions.
+
+```js
+// app/services/ajax.js
+
+import Ember from 'ember';
+import AjaxService from 'ember-ajax/services/ajax';
+
+export default AjaxService.extend({
+  allowedHosts: [
+    /\.example\./,
+    'foo.bar.com',
+  ]
+});
+```
+
+
 ### Custom Endpoint Path
 
 The `namespace` property can be used to prefix requests with a specific url namespace.

--- a/addon/ajax-request.js
+++ b/addon/ajax-request.js
@@ -274,9 +274,10 @@ export default class AjaxRequest {
     const urlObject = new RequestURL(url);
     const allowedHosts = get(this, 'allowedHosts') || Ember.A();
     // Add headers on relative URLs
+
     if (!urlObject.isAbsolute) {
       return true;
-    } else if (allowedHosts.find(this.matchHosts.bind(this, urlObject.hostname))) {
+    } else if (allowedHosts.find((matcher) => this.matchHosts(urlObject.hostname, matcher))) {
       return true;
     }
 

--- a/addon/ajax-request.js
+++ b/addon/ajax-request.js
@@ -246,7 +246,7 @@ export default class AjaxRequest {
     } else if (typeof matcher === 'string') {
       return matcher === host;
     } else {
-      Ember.Logger.warn('allowedHosts only handles strings or regexes.', matcher, 'is neither.');
+      Ember.Logger.warn('trustedHosts only handles strings or regexes.', matcher, 'is neither.');
       return false;
     }
   }
@@ -275,12 +275,12 @@ export default class AjaxRequest {
     host = host || get(this, 'host') || '';
 
     const urlObject = new RequestURL(url);
-    const allowedHosts = get(this, 'allowedHosts') || Ember.A();
+    const trustedHosts = get(this, 'trustedHosts') || Ember.A();
     // Add headers on relative URLs
 
     if (!urlObject.isAbsolute) {
       return true;
-    } else if (allowedHosts.find((matcher) => this._matchHosts(urlObject.hostname, matcher))) {
+    } else if (trustedHosts.find((matcher) => this._matchHosts(urlObject.hostname, matcher))) {
       return true;
     }
 

--- a/addon/ajax-request.js
+++ b/addon/ajax-request.js
@@ -237,7 +237,7 @@ export default class AjaxRequest {
    * @public
    * @param {String} host the host you are sending too
    * @param {RegExp | String} matcher a string or regex that you can match the host to.
-   * @returns {Boolrsn} if the host passed the matcher
+   * @returns {Boolean} if the host passed the matcher
    */
 
   matchHosts(host, matcher) {

--- a/addon/ajax-request.js
+++ b/addon/ajax-request.js
@@ -231,6 +231,24 @@ export default class AjaxRequest {
   }
 
   /**
+   * Match the host to a provided array of host or regex's that can match a host
+   *
+   * @method matchHosts
+   * @public
+   * @param {String} host the host you are sending too
+   * @param {RegExp | String} matcher a string or regex that you can match the host to.
+   * @returns {Boolrsn} if the host passed the matcher
+   */
+
+  matchHosts(host, matcher) {
+    if (matcher.constructor === RegExp) {
+      return matcher.test(host);
+    } else {
+      return matcher === host;
+    }
+  }
+
+  /**
    * Determine whether the headers should be added for this request
    *
    * This hook is used to help prevent sending headers to every host, regardless
@@ -254,8 +272,11 @@ export default class AjaxRequest {
     host = host || get(this, 'host') || '';
 
     const urlObject = new RequestURL(url);
+    const allowedHosts = get(this, 'allowedHosts') || Ember.A();
     // Add headers on relative URLs
     if (!urlObject.isAbsolute) {
+      return true;
+    } else if (allowedHosts.find(this.matchHosts.bind(this, urlObject.hostname))) {
       return true;
     }
 

--- a/addon/ajax-request.js
+++ b/addon/ajax-request.js
@@ -234,13 +234,13 @@ export default class AjaxRequest {
    * Match the host to a provided array of strings or regexes that can match to a host
    *
    * @method matchHosts
-   * @public
+   * @private
    * @param {String} host the host you are sending too
    * @param {RegExp | String} matcher a string or regex that you can match the host to.
    * @returns {Boolean} if the host passed the matcher
    */
 
-  matchHosts(host, matcher) {
+  _matchHosts(host, matcher) {
     if (matcher.constructor === RegExp) {
       return matcher.test(host);
     } else if (typeof matcher === 'string') {

--- a/addon/ajax-request.js
+++ b/addon/ajax-request.js
@@ -243,8 +243,11 @@ export default class AjaxRequest {
   matchHosts(host, matcher) {
     if (matcher.constructor === RegExp) {
       return matcher.test(host);
-    } else {
+    } else if (typeof matcher === 'string') {
       return matcher === host;
+    } else {
+      Ember.Logger.warn('allowedHosts only handles strings or regexes.', matcher, 'is neither.');
+      return false;
     }
   }
 

--- a/addon/ajax-request.js
+++ b/addon/ajax-request.js
@@ -231,7 +231,7 @@ export default class AjaxRequest {
   }
 
   /**
-   * Match the host to a provided array of host or regex's that can match a host
+   * Match the host to a provided array of strings or regexes that can match to a host
    *
    * @method matchHosts
    * @public

--- a/addon/ajax-request.js
+++ b/addon/ajax-request.js
@@ -280,7 +280,7 @@ export default class AjaxRequest {
 
     if (!urlObject.isAbsolute) {
       return true;
-    } else if (allowedHosts.find((matcher) => this.matchHosts(urlObject.hostname, matcher))) {
+    } else if (allowedHosts.find((matcher) => this._matchHosts(urlObject.hostname, matcher))) {
       return true;
     }
 

--- a/tests/unit/ajax-request-test.js
+++ b/tests/unit/ajax-request-test.js
@@ -69,7 +69,7 @@ test('headers are set if the URL is relative', function(assert) {
   return service.request('/some/relative/url');
 });
 
-test('headers are set if the URL matches one of the RegExp allowedHosts', function(assert) {
+test('headers are set if the URL matches one of the RegExp trustedHosts', function(assert) {
   assert.expect(1);
 
   server.get('http://my.example.com', (req) => {
@@ -82,7 +82,7 @@ test('headers are set if the URL matches one of the RegExp allowedHosts', functi
     get host() {
       return 'some-other-host.com';
     }
-    get allowedHosts() {
+    get trustedHosts() {
       return Ember.A([
         4,
         'notmy.example.com',
@@ -97,7 +97,7 @@ test('headers are set if the URL matches one of the RegExp allowedHosts', functi
   return service.request('http://my.example.com');
 });
 
-test('headers are set if the URL matches one of the string allowedHosts', function(assert) {
+test('headers are set if the URL matches one of the string trustedHosts', function(assert) {
   assert.expect(1);
 
   server.get('http://foo.bar.com', (req) => {
@@ -110,7 +110,7 @@ test('headers are set if the URL matches one of the string allowedHosts', functi
     get host() {
       return 'some-other-host.com';
     }
-    get allowedHosts() {
+    get trustedHosts() {
       return Ember.A([
         'notmy.example.com',
         /example\./,

--- a/tests/unit/ajax-request-test.js
+++ b/tests/unit/ajax-request-test.js
@@ -69,7 +69,7 @@ test('headers are set if the URL is relative', function(assert) {
   return service.request('/some/relative/url');
 });
 
-test('headers are set if the URL matches one of the allowedHosts', function(assert) {
+test('headers are set if the URL matches one of the RegExp allowedHosts', function(assert) {
   assert.expect(1);
 
   server.get('http://my.example.com', (req) => {
@@ -83,7 +83,11 @@ test('headers are set if the URL matches one of the allowedHosts', function(asse
       return 'some-other-host.com';
     }
     get allowedHosts() {
-      return Ember.A([/example\./]);
+      return Ember.A([
+        4,
+        'notmy.example.com',
+        /example\./
+      ]);
     }
     get headers() {
       return { 'Content-Type': 'application/json', 'Other-key': 'Other Value' };
@@ -91,6 +95,34 @@ test('headers are set if the URL matches one of the allowedHosts', function(asse
   }
   const service = new RequestWithHeaders();
   return service.request('http://my.example.com');
+});
+
+test('headers are set if the URL matches one of the string allowedHosts', function(assert) {
+  assert.expect(1);
+
+  server.get('http://foo.bar.com', (req) => {
+    const { requestHeaders } = req;
+    assert.equal(requestHeaders['Other-key'], 'Other Value');
+    return jsonResponse();
+  });
+
+  class RequestWithHeaders extends AjaxRequest {
+    get host() {
+      return 'some-other-host.com';
+    }
+    get allowedHosts() {
+      return Ember.A([
+        'notmy.example.com',
+        /example\./,
+        'foo.bar.com'
+      ]);
+    }
+    get headers() {
+      return { 'Content-Type': 'application/json', 'Other-key': 'Other Value' };
+    }
+  }
+  const service = new RequestWithHeaders();
+  return service.request('http://foo.bar.com');
 });
 
 test('headers are not set if the URL does not match the host', function(assert) {

--- a/tests/unit/ajax-request-test.js
+++ b/tests/unit/ajax-request-test.js
@@ -69,6 +69,30 @@ test('headers are set if the URL is relative', function(assert) {
   return service.request('/some/relative/url');
 });
 
+test('headers are set if the URL matches one of the allowedHosts', function(assert) {
+  assert.expect(1);
+
+  server.get('http://my.example.com', (req) => {
+    const { requestHeaders } = req;
+    assert.equal(requestHeaders['Other-key'], 'Other Value');
+    return jsonResponse();
+  });
+
+  class RequestWithHeaders extends AjaxRequest {
+    get host() {
+      return 'some-other-host.com';
+    }
+    get allowedHosts() {
+      return Ember.A([/example\./]);
+    }
+    get headers() {
+      return { 'Content-Type': 'application/json', 'Other-key': 'Other Value' };
+    }
+  }
+  const service = new RequestWithHeaders();
+  return service.request('http://my.example.com');
+});
+
 test('headers are not set if the URL does not match the host', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
Useful for SOA architectures with different domains communicating across CORS. I could have overwritten the `_shouldSendHeaders` method, but wanted a more strait forward way to tell what domains where whitelisted to pass headers too. Any feedback is much appreciated!