### PR TITLE
Help users avoid using `.get` for requests

### DIFF
--- a/addon/ajax-request.js
+++ b/addon/ajax-request.js
@@ -20,6 +20,7 @@ import { RequestURL } from './utils/url-helpers';
 
 const {
   $,
+  Error: EmberError,
   RSVP: { Promise },
   get,
   isPresent,
@@ -121,6 +122,22 @@ export default class AjaxRequest {
    */
   del(url, options) {
     return this.request(url, this._addTypeToOptionsFor(options, 'DELETE'));
+  }
+
+  /**
+   * Wrap the `.get` method so that we issue a warning if
+   *
+   * Since `.get` is both an AJAX pattern _and_ an Ember pattern, we want to try
+   * to warn users when they try using `.get` to make a request
+   *
+   * @method get
+   * @public
+   */
+  get(url) {
+    if (arguments.length > 1 || url.charAt(0) === '/') {
+      throw new EmberError('It seems you tried to use `.get` to make a request! Use the `.request` method instead.');
+    }
+    return this._super(...arguments);
   }
 
   // forcibly manipulates the options hash to include the HTTP method on the type key

--- a/tests/unit/ajax-request-test.js
+++ b/tests/unit/ajax-request-test.js
@@ -436,6 +436,24 @@ test('it creates a detailed error message for unmatched server errors with a tex
     });
 });
 
+test('it throws an error when the user tries to use `.get` to make a request', function(assert) {
+  assert.expect(3);
+
+  const service = new AjaxRequest();
+
+  assert.throws(function() {
+    service.get('someProperty');
+  }, 'Throws an error when using `.get` on the class with any property');
+
+  assert.throws(function() {
+    service.get('/users');
+  }, 'Throws an error when using `.get` on the class with a relative URL');
+
+  assert.throws(function() {
+    service.get('/users', {});
+  }, 'Throws an error when using `.get` with multiple parameters');
+});
+
 const errorHandlerTest = (status, errorClass) => {
   test(`${status} handler`, function(assert) {
     server.get('/posts', jsonFactory(status));

--- a/tests/unit/services/ajax-test.js
+++ b/tests/unit/services/ajax-test.js
@@ -37,3 +37,21 @@ test('allows headers to be specified as a computed property', function(assert) {
   service = CustomService.create();
   return service.request('example.com');
 });
+
+test('it throws an error when the user tries to use `.get` to make a request', function(assert) {
+  assert.expect(3);
+
+  service = Service.create({
+    someProperty: 'some value'
+  });
+
+  assert.equal(service.get('someProperty'), 'some value', 'Retrieved a regular property');
+
+  assert.throws(function() {
+    service.get('/users');
+  }, 'Throws an error when using `.get` on the class with a relative URL');
+
+  assert.throws(function() {
+    service.get('/users', {});
+  }, 'Throws an error when using `.get` with multiple parameters');
+});


### PR DESCRIPTION
Since `.get` might be used for making a `GET` request, but conflicts with Ember's API for getting properties, we can try to detect the incorrect usage and provide the user of the library with direction toward using the correct method.

Closes #51