### PR TITLE
Basic fastboot support

### DIFF
--- a/addon/ajax-request.js
+++ b/addon/ajax-request.js
@@ -19,6 +19,7 @@ import {
 } from './errors';
 import parseResponseHeaders from './utils/parse-response-headers';
 import { RequestURL } from './utils/url-helpers';
+import ajax from './utils/ajax';
 
 const {
   $,
@@ -123,7 +124,7 @@ export default class AjaxRequest {
 
       this.pendingRequestCount++;
 
-      $.ajax(hash);
+      ajax(hash);
     }, `ember-ajax: ${hash.type} ${hash.url}`);
   }
 
@@ -489,7 +490,7 @@ export default class AjaxRequest {
     let json = responseText;
 
     try {
-      json = Ember.$.parseJSON(responseText);
+      json = $.parseJSON(responseText);
     } catch (e) {}
 
     return json;

--- a/addon/utils/ajax.js
+++ b/addon/utils/ajax.js
@@ -1,0 +1,9 @@
+/* global najax */
+import Ember from 'ember';
+import isFastBoot from './is-fastboot';
+
+const {
+  $
+} = Ember;
+
+export default isFastBoot ? najax : $.ajax;

--- a/addon/utils/is-fastboot.js
+++ b/addon/utils/is-fastboot.js
@@ -1,0 +1,3 @@
+/* global FastBoot */
+const isFastBoot = typeof FastBoot !== 'undefined';
+export default isFastBoot;

--- a/addon/utils/url-helpers.js
+++ b/addon/utils/url-helpers.js
@@ -1,4 +1,5 @@
-/* global require, module */
+/* global require, module, URL */
+import isFastBoot from './is-fastboot';
 
 const absoluteUrlRegex = /^(http|https)/;
 
@@ -8,7 +9,26 @@ const absoluteUrlRegex = /^(http|https)/;
  * http://www.sitepoint.com/url-parsing-isomorphic-javascript/
  */
 const isNode = (typeof module === 'object' && module.exports);
-const url = (isNode ? require('url') : document.createElement('a'));
+const url = getUrlModule();
+
+/**
+ * Get the node url module or an anchor element
+ *
+ * @private
+ * @return {Object|HTMLAnchorElement} Object to parse urls
+ */
+function getUrlModule() {
+  if (isFastBoot) {
+    // ember-fastboot-server provides the node url module as URL global
+    return URL;
+  }
+
+  if (isNode) {
+    return require('url');
+  }
+
+  return document.createElement('a');
+}
 
 /**
  * Parse a URL string into an object that defines its structure
@@ -28,7 +48,7 @@ const url = (isNode ? require('url') : document.createElement('a'));
  */
 function parseUrl(str) {
   let fullObject;
-  if (isNode) {
+  if (isNode || isFastBoot) {
     fullObject = url.parse(str);
   } else {
     url.href = str;


### PR DESCRIPTION
This adds basic fastboot support by using the provided `URL` module by ember-fastboot-server and [`najax`](https://github.com/najaxjs/najax).

I get warnings as `najax` does not implement `jqXHR.getAllResponseHeaders()`, but this should work for basic ajax requests.
It seems to be implemented in `najax` on the `master` (https://github.com/najaxjs/najax/pull/26) branch, I'm not sure if this is released in a npm package yet.