### PR TITLE
Add a `delete` alias

### DIFF
--- a/addon/ajax-request.js
+++ b/addon/ajax-request.js
@@ -164,8 +164,8 @@ export default class AjaxRequest {
    * alias for `del()`
    * @public
    */
-  delete(url, options) {
-    return this.del(url, options);
+  delete(...args) {
+    return this.del(...args);
   }
 
   /**

--- a/addon/ajax-request.js
+++ b/addon/ajax-request.js
@@ -164,8 +164,8 @@ export default class AjaxRequest {
    * alias for `del()`
    * @public
    */
-  delete(...args) {
-    return this.del(...args);
+  delete() {
+    return this.del(...arguments);
   }
 
   /**

--- a/addon/ajax-request.js
+++ b/addon/ajax-request.js
@@ -160,6 +160,15 @@ export default class AjaxRequest {
   }
 
   /**
+   * calls `request()` but forces `options.type` to `DELETE`
+   * alias for `del()`
+   * @public
+   */
+  delete(url, options) {
+    return this.del(url, options);
+  }
+
+  /**
    * Wrap the `.get` method so that we issue a warning if
    *
    * Since `.get` is both an AJAX pattern _and_ an Ember pattern, we want to try

--- a/tests/unit/ajax-request-test.js
+++ b/tests/unit/ajax-request-test.js
@@ -331,6 +331,21 @@ test('del() promise label is correct', function(assert) {
   });
 });
 
+test('delete() promise label is correct', function(assert) {
+  const service = new AjaxRequest();
+  const url = '/posts/1';
+  const serverResponse = [200, { 'Content-Type': 'application/json' }, JSON.stringify({})];
+
+  server.delete(url, () => serverResponse);
+
+  const deletePromise = service.delete(url);
+  assert.equal(deletePromise._label, 'ember-ajax: DELETE /posts/1 response');
+
+  return deletePromise.then(function(response) {
+    assert.deepEqual(response, {});
+  });
+});
+
 test('request with method option makes the correct type of request', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
Since the other methods map to the HTTP type name (PATCH => `patch()`, POST => `post()`) it makes sense to do the same for `delete`. Does this sound like a good idea?