### PR TITLE
isAjaxError helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,12 +171,6 @@ You can even leave off the forward slash if you'd like:
 request('users/me')
 ```
 
-### Error handling
-
-`ember-ajax` provides built in error classes that you can use to check the error
-that was returned by the response. This allows you to restrict determination of
-error result to the service instead of sprinkling it around your code.
-
 #### Customize isSuccess
 
 Some APIs respond with status code 200, even though an error has occurred and
@@ -201,6 +195,12 @@ export default AjaxService.extend({
 });
 ```
 
+### Error handling
+
+`ember-ajax` provides built in error classes that you can use to check the error
+that was returned by the response. This allows you to restrict determination of
+error result to the service instead of sprinkling it around your code.
+
 #### Built in error types
 
 `ember-ajax` has built-in error types that will be returned from the service in the event of an error:
@@ -214,6 +214,8 @@ export default AjaxService.extend({
 * `AbortError`
 * `TimeoutError`
 
+All of the above errors are subtypes of `AjaxError`.
+
 #### Error detection helpers
 
 `ember-ajax` comes with helper functions for matching response errors to their respective `ember-ajax` error type. Each of the errors listed above has a corresponding `is*` function (e.g., `isBadRequestError`).
@@ -222,7 +224,7 @@ Use of these functions is **strongly encouraged** to help eliminate the need for
 
 ```js
 import Ember from 'ember';
-import {isNotFoundError, isForbiddenError} from 'ember-ajax/errors';
+import {isAjaxError, isNotFoundError, isForbiddenError} from 'ember-ajax/errors';
 
 export default Ember.Route.extend({
   ajax: Ember.inject.service(),
@@ -238,6 +240,11 @@ export default Ember.Route.extend({
 
         if (isForbiddenError(error)) {
           // handle 403 errors here
+          return;
+        }
+
+        if(isAjaxError(error)) {
+          // handle all other AjaxErrors here
           return;
         }
 

--- a/addon/ajax-request.js
+++ b/addon/ajax-request.js
@@ -9,6 +9,7 @@ import {
   TimeoutError,
   AbortError,
   ServerError,
+  isAjaxError,
   isUnauthorizedError,
   isForbiddenError,
   isInvalidError,
@@ -90,7 +91,7 @@ export default class AjaxRequest {
 
         this.pendingRequestCount--;
 
-        if (response instanceof AjaxError) {
+        if (isAjaxError(response)) {
           run.join(null, reject, { payload, textStatus, jqXHR, response });
         } else {
           run.join(null, resolve, { payload, textStatus, jqXHR, response });

--- a/addon/errors.js
+++ b/addon/errors.js
@@ -101,7 +101,18 @@ export function ServerError(errors) {
 ServerError.prototype = Object.create(AjaxError.prototype);
 
 /**
- * Checks if the given status code or AjaxError obejct represents an
+ * Checks if the given error is or inherits from AjaxError
+ * @method isAjaxError
+ * @public
+ * @param  {Error} error
+ * @return {Boolean}
+ */
+export function isAjaxError(error) {
+  return error instanceof AjaxError;
+}
+
+/**
+ * Checks if the given status code or AjaxError object represents an
  * unauthorized request error
  * @method isUnauthorizedError
  * @public
@@ -109,7 +120,7 @@ ServerError.prototype = Object.create(AjaxError.prototype);
  * @return {Boolean}
  */
 export function isUnauthorizedError(error) {
-  if (error instanceof AjaxError) {
+  if (isAjaxError(error)) {
     return error instanceof UnauthorizedError;
   } else {
     return error === 401;
@@ -125,7 +136,7 @@ export function isUnauthorizedError(error) {
  * @return {Boolean}
  */
 export function isForbiddenError(error) {
-  if (error instanceof AjaxError) {
+  if (isAjaxError(error)) {
     return error instanceof ForbiddenError;
   } else {
     return error === 403;
@@ -141,7 +152,7 @@ export function isForbiddenError(error) {
  * @return {Boolean}
  */
 export function isInvalidError(error) {
-  if (error instanceof AjaxError) {
+  if (isAjaxError(error)) {
     return error instanceof InvalidError;
   } else {
     return error === 422;
@@ -157,7 +168,7 @@ export function isInvalidError(error) {
  * @return {Boolean}
  */
 export function isBadRequestError(error) {
-  if (error instanceof AjaxError) {
+  if (isAjaxError(error)) {
     return error instanceof BadRequestError;
   } else {
     return error === 400;
@@ -173,7 +184,7 @@ export function isBadRequestError(error) {
  * @return {Boolean}
  */
 export function isNotFoundError(error) {
-  if (error instanceof AjaxError) {
+  if (isAjaxError(error)) {
     return error instanceof NotFoundError;
   } else {
     return error === 404;
@@ -212,7 +223,7 @@ export function isAbortError(error) {
  * @return {Boolean}
  */
 export function isServerError(error) {
-  if (error instanceof AjaxError) {
+  if (isAjaxError(error)) {
     return error instanceof ServerError;
   } else {
     return error >= 500 && error < 600;

--- a/tests/unit/errors-test.js
+++ b/tests/unit/errors-test.js
@@ -9,6 +9,7 @@ import {
   InvalidError,
   UnauthorizedError,
   ForbiddenError,
+  NotFoundError,
   BadRequestError,
   ServerError,
   TimeoutError,
@@ -16,6 +17,7 @@ import {
   isAjaxError,
   isUnauthorizedError,
   isForbiddenError,
+  isNotFoundError,
   isInvalidError,
   isBadRequestError,
   isServerError,
@@ -48,6 +50,12 @@ test('ForbiddenError', function(assert) {
   const error = new ForbiddenError();
   assert.ok(error instanceof Error);
   assert.ok(error instanceof ForbiddenError);
+});
+
+test('NotFoundError', function(assert) {
+  const error = new NotFoundError();
+  assert.ok(error instanceof Error);
+  assert.ok(error instanceof NotFoundError);
 });
 
 test('BadRequestError', function(assert) {
@@ -90,6 +98,18 @@ test('isForbiddenError: detects error code correctly', function(assert) {
 test('isForbiddenError: detects error class correctly', function(assert) {
   const error = new ForbiddenError();
   assert.ok(isForbiddenError(error));
+});
+
+test('isNotFoundError: detects error code correctly', function(assert) {
+  assert.ok(isNotFoundError(404));
+  assert.notOk(isNotFoundError(400));
+});
+
+test('isNotFoundError: detects error class correctly', function(assert) {
+  const error = new NotFoundError();
+  const otherError = new Error();
+  assert.ok(isNotFoundError(error));
+  assert.notOk(isNotFoundError(otherError));
 });
 
 test('isInvalidError: detects error code correctly', function(assert) {

--- a/tests/unit/errors-test.js
+++ b/tests/unit/errors-test.js
@@ -13,6 +13,7 @@ import {
   ServerError,
   TimeoutError,
   AbortError,
+  isAjaxError,
   isUnauthorizedError,
   isForbiddenError,
   isInvalidError,
@@ -114,6 +115,15 @@ test('isServerError: detects error code correctly', function(assert) {
   assert.ok(isServerError(500));
   assert.ok(isServerError(599));
   assert.notOk(isServerError(600));
+});
+
+test('isAjaxError: detects error class correctly', function(assert) {
+  const ajaxError = new AjaxError();
+  const notAjaxError = new Error();
+  const ajaxErrorSubtype = new BadRequestError();
+  assert.ok(isAjaxError(ajaxError));
+  assert.notOk(isAjaxError(notAjaxError));
+  assert.ok(isAjaxError(ajaxErrorSubtype));
 });
 
 test('isServerError: detects error class correctly', function(assert) {


### PR DESCRIPTION
Closes #90 

* Adds an `isAjaxError` helper function to match the other `is*` error helpers.
* Updates the README to mention `AjaxError` and `isAjaxError`.
* Adds test coverage for `NotFoundError`.
