### PR TITLE
Prevent removing trailing slash in request URL

### DIFF
--- a/addon/utils/url-helpers.js
+++ b/addon/utils/url-helpers.js
@@ -1,7 +1,7 @@
 /* global require, module, URL */
 import isFastBoot from './is-fastboot';
 
-const absoluteUrlRegex = /^(http|https)/;
+const completeUrlRegex = /^(http|https)/;
 
 /*
  * Isomorphic URL parsing
@@ -81,8 +81,8 @@ export class RequestURL {
     return this._url;
   }
 
-  get isAbsolute() {
-    return this.url.match(absoluteUrlRegex);
+  get isComplete() {
+    return this.url.match(completeUrlRegex);
   }
 
   set url(value) {

--- a/tests/unit/utils/url-helpers-test.js
+++ b/tests/unit/utils/url-helpers-test.js
@@ -15,18 +15,18 @@ test('RequestURL Class: parses the parts of a URL correctly', function(assert) {
   assert.equal(obj.hash, '#hash');
 });
 
-test('RequestURL Class: can detect if the url is absolute', function(assert) {
+test('RequestURL Class: can detect if the url is complete', function(assert) {
   const obj = new RequestURL('http://google.com/test');
-  assert.ok(obj.isAbsolute);
+  assert.ok(obj.isComplete);
 
   const obj2 = new RequestURL('google.com/test');
-  assert.notOk(obj2.isAbsolute);
+  assert.notOk(obj2.isComplete);
 
   const obj3 = new RequestURL('/test');
-  assert.notOk(obj3.isAbsolute);
+  assert.notOk(obj3.isComplete);
 
   const obj4 = new RequestURL('test/http/http');
-  assert.notOk(obj4.isAbsolute);
+  assert.notOk(obj4.isComplete);
 });
 
 test('RequestURL Class: can detect if two hosts are the same', function(assert) {


### PR DESCRIPTION
The old way of building a URL was too brittle and didn't cover a lot of the different cases that could take place, in different combinations of the host, namespace, and segment having or not having slashes included.

The new approach implemented here handles the various cases correctly, and ensures that we do not remove a trailing slash if one was provided.