### PR TITLE
Add service property for default contentType

### DIFF
--- a/addon/mixins/ajax-request.js
+++ b/addon/mixins/ajax-request.js
@@ -76,6 +76,17 @@ if (testing) {
 
 export default Mixin.create({
 
+  /**
+   * The default value for the request `contentType`
+   *
+   * For now, defaults to the same value that jQuery would assign.  In the
+   * future, the default value will be for JSON requests.
+   * @property {string} contentType
+   * @public
+   * @default
+   */
+  contentType: 'application/x-www-form-urlencoded; charset=UTF-8',
+
   request(url, options) {
     const hash = this.options(url, options);
     return new Promise((resolve, reject) => {
@@ -237,6 +248,7 @@ export default Mixin.create({
     options.url = this._buildURL(url, options);
     options.type = options.type || 'GET';
     options.dataType = options.dataType || 'json';
+    options.contentType = options.contentType || get(this, 'contentType');
 
     if (this._shouldSendHeaders(options)) {
       options.headers = this._getFullHeadersHash(options.headers);

--- a/tests/unit/ajax-request-test.js
+++ b/tests/unit/ajax-request-test.js
@@ -148,6 +148,7 @@ test('options() sets raw data', function(assert) {
   const ajaxOptions = service.options(url, { type, data: { key: 'value' } });
 
   assert.deepEqual(ajaxOptions, {
+    contentType: 'application/x-www-form-urlencoded; charset=UTF-8',
     data: {
       key: 'value'
     },
@@ -189,11 +190,26 @@ test('options() empty data', function(assert) {
   const ajaxOptions = service.options(url, { type });
 
   assert.deepEqual(ajaxOptions, {
+    contentType: 'application/x-www-form-urlencoded; charset=UTF-8',
     dataType: 'json',
     headers: {},
     type: 'POST',
     url: '/test'
   });
+});
+
+test('can override the default `contentType` for the service', function(assert) {
+  const defaultContentType = 'application/json';
+
+  class AjaxServiceWithDefaultContentType extends AjaxRequest {
+    get contentType() {
+      return defaultContentType;
+    }
+  }
+
+  const service = new AjaxServiceWithDefaultContentType();
+  const options = service.options('');
+  assert.equal(options.contentType, defaultContentType);
 });
 
 test('options() type defaults to GET', function(assert) {


### PR DESCRIPTION
This PR is closesly related to #79.  Since going and changing the default content type would be a breaking change, we're planning to make that happen for version `3.0`.  For the time being, this PR allows the service to set a `contentType` property that will be used by default, which itself defaults to the same value that jQuery itself would use.  This makes the default value much more explcit, which will hopefully help mitigate errors due to the default not being clear, as well as provides a clear pathway for changing the default value in the next major version.