### PR TITLE
add failed test for duplicate namespace

### DIFF
--- a/tests/acceptance/ember-data-integration-test.js
+++ b/tests/acceptance/ember-data-integration-test.js
@@ -6,6 +6,7 @@ const { equal } = assert;
 import destroyApp from 'dummy/tests/helpers/destroy-app';
 import startApp from 'dummy/tests/helpers/start-app';
 
+import AjaxService from 'ember-ajax/services/ajax';
 import Pretender from 'pretender';
 import { jsonResponse } from 'dummy/tests/helpers/json';
 
@@ -22,6 +23,31 @@ describe('Acceptance | ember data integration', function() {
   });
 
   it('can apply the Ember Ajax mixin to an Ember Data adapter', function() {
+    server.get('api/posts/1', function() {
+      return jsonResponse(200, {
+        data: {
+          id: 1,
+          type: 'post',
+          attributes: {
+            title: 'Foo'
+          }
+        }
+      });
+    });
+
+    visit('/ember-data-test');
+
+    andThen(function() {
+      equal(currentURL(), '/ember-data-test');
+    });
+  });
+
+  it('can set the namespace for all ajax requests', function() {
+    application.register('service:ajaxWithNs', AjaxService.extend({
+      namespace: 'api'
+    }));
+    application.inject('adapter:application', 'ajaxService', 'service:ajaxWithNs');
+
     server.get('api/posts/1', function() {
       return jsonResponse(200, {
         data: {


### PR DESCRIPTION
If I set the namespace in the ajax service, and I use ember-data integration from #114, the mixin copies the namespace into the application adapter. The namespace is added to the URL in both places and gets repeated:
```
not ok 2 PhantomJS 2.1 - Acceptance | ember data integration can set the namespace for all ajax requests
    ---
        message: >
            Pretender intercepted GET /api/api/posts/1 but no handler was defined for this type of request
```
Workaround: explicitly set `namespace: null` in the application adapter