### PR TITLE
fix multiple calls to the options method when using the ajax-support mixin

### DIFF
--- a/addon/mixins/ajax-support.js
+++ b/addon/mixins/ajax-support.js
@@ -34,13 +34,8 @@ export default Mixin.create({
    */
   headers: alias('ajaxService.headers'),
 
-  ajax(url, type, options) {
-    options = this.ajaxOptions(...arguments);
-    return this.get('ajaxService').request(url, options);
-  },
-
-  ajaxOptions(url, type, options = {}) {
+  ajax(url, type, options={}) {
     options.type = type;
-    return this.get('ajaxService').options(url, options);
+    return this.get('ajaxService').request(url, options);
   }
 });


### PR DESCRIPTION
The ajax-support mixin currently calls ember-data adapter's `ajaxOptions` method which is overriden by the same mixin and calls the `options` method. But the `options` method is then again called by the ajaxService, as a result it is called twice.

To fix this ajaxOptions is not overriden anymore in the ajax-support mixin, and is
not called anymore by the ajax method, as it should not be needed by ember-ajax I think
and is a private method of the ember-data adapter.