### PR TITLE
Replaced $.parseJSON with JSON.parse. #159

### DIFF
--- a/addon/mixins/ajax-request.js
+++ b/addon/mixins/ajax-request.js
@@ -776,7 +776,7 @@ export default Mixin.create({
    */
   parseErrorResponse(responseText) {
     try {
-      return $.parseJSON(responseText);
+      return JSON.parse(responseText);
     } catch(e) {
       return responseText;
     }


### PR DESCRIPTION
The method `$.parseJSON` has been deprecated in jQuery 3+, they suggest to replace it with `JSON.parse`. This pull request does the suggested replace. This should not break any code because `JSON.parse` is supported by all major browsers and IE8+.