### PR TITLE
Ensure Adapter Ajax Options are Respected

### DIFF
--- a/addon/mixins/ajax-support.js
+++ b/addon/mixins/ajax-support.js
@@ -35,7 +35,8 @@ export default Mixin.create({
   headers: alias('ajaxService.headers'),
 
   ajax(url, type, options = {}) {
-    options.type = type;
-    return this.get('ajaxService').request(url, options);
+    let augmentedOptions = this.ajaxOptions(...arguments);
+
+    return this.get('ajaxService').request(url, augmentedOptions);
   }
 });

--- a/tests/acceptance/ember-data-integration-test.js
+++ b/tests/acceptance/ember-data-integration-test.js
@@ -66,4 +66,27 @@ describe('Acceptance | ember data integration', function() {
       equal(currentURL(), '/ember-data-test');
     });
   });
+
+  it('respects ajaxOptions on the target adapter', function() {
+    server.get('api/posts/1', function({ requestHeaders }) {
+      let xSillyHeader = requestHeaders['X-Silly-Option'];
+      equal(xSillyHeader, 'Hi!');
+
+      return jsonResponse(200, {
+        data: {
+          id: 1,
+          type: 'post',
+          attributes: {
+            title: 'Foo'
+          }
+        }
+      });
+    });
+
+    visit('/ember-data-test');
+
+    andThen(function() {
+      equal(currentURL(), '/ember-data-test');
+    });
+  });
 });

--- a/tests/dummy/app/adapters/application.js
+++ b/tests/dummy/app/adapters/application.js
@@ -4,5 +4,15 @@ import AjaxServiceSupport from 'ember-ajax/mixins/ajax-support';
 const { JSONAPIAdapter } = DS;
 
 export default JSONAPIAdapter.extend(AjaxServiceSupport, {
-  namespace: 'api'
+  namespace: 'api',
+
+  ajaxOptions() {
+    let hash = this._super(...arguments);
+
+    hash.headers = {
+      'X-Silly-Option': 'Hi!'
+    };
+
+    return hash;
+  }
 });


### PR DESCRIPTION
The AjaxSupport mixin wasn't calling the adapter's `ajaxOptions` method.
This was resulting in malformed requests for some users.

Resolves #169