### PR TITLE
Refactor Error Classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
+  - EMBER_TRY_SCENARIO=ember-1-13
 
 matrix:
   fast_finish: true

--- a/addon/errors.js
+++ b/addon/errors.js
@@ -4,17 +4,13 @@ const { Error: EmberError } = Ember;
 
 /**
  * @class AjaxError
- * @private
+ * @public
+ * @extends Ember.Error
  */
-export function AjaxError(errors, message = 'Ajax operation failed') {
+export function AjaxError(payload, message = 'Ajax operation failed') {
   EmberError.call(this, message);
 
-  this.errors = errors || [
-    {
-      title: 'Ajax Error',
-      detail: message
-    }
-  ];
+  this.payload = payload;
 }
 
 AjaxError.prototype = Object.create(EmberError.prototype);
@@ -24,8 +20,8 @@ AjaxError.prototype = Object.create(EmberError.prototype);
  * @public
  * @extends AjaxError
  */
-export function InvalidError(errors) {
-  AjaxError.call(this, errors, 'Request was rejected because it was invalid');
+export function InvalidError(payload) {
+  AjaxError.call(this, payload, 'Request was rejected because it was invalid');
 }
 
 InvalidError.prototype = Object.create(AjaxError.prototype);
@@ -35,8 +31,8 @@ InvalidError.prototype = Object.create(AjaxError.prototype);
  * @public
  * @extends AjaxError
  */
-export function UnauthorizedError(errors) {
-  AjaxError.call(this, errors, 'Ajax authorization failed');
+export function UnauthorizedError(payload) {
+  AjaxError.call(this, payload, 'Ajax authorization failed');
 }
 
 UnauthorizedError.prototype = Object.create(AjaxError.prototype);
@@ -46,8 +42,8 @@ UnauthorizedError.prototype = Object.create(AjaxError.prototype);
  * @public
  * @extends AjaxError
  */
-export function ForbiddenError(errors) {
-  AjaxError.call(this, errors,
+export function ForbiddenError(payload) {
+  AjaxError.call(this, payload,
     'Request was rejected because user is not permitted to perform this operation.');
 }
 
@@ -58,8 +54,8 @@ ForbiddenError.prototype = Object.create(AjaxError.prototype);
  * @public
  * @extends AjaxError
  */
-export function BadRequestError(errors) {
-  AjaxError.call(this, errors, 'Request was formatted incorrectly.');
+export function BadRequestError(payload) {
+  AjaxError.call(this, payload, 'Request was formatted incorrectly.');
 }
 
 BadRequestError.prototype = Object.create(AjaxError.prototype);
@@ -69,8 +65,8 @@ BadRequestError.prototype = Object.create(AjaxError.prototype);
  * @public
  * @extends AjaxError
  */
-export function NotFoundError(errors) {
-  AjaxError.call(this, errors, 'Resource was not found.');
+export function NotFoundError(payload) {
+  AjaxError.call(this, payload, 'Resource was not found.');
 }
 
 NotFoundError.prototype = Object.create(AjaxError.prototype);
@@ -102,8 +98,8 @@ AbortError.prototype = Object.create(AjaxError.prototype);
  * @public
  * @extends AjaxError
  */
-export function ConflictError(errors) {
-  AjaxError.call(this, errors, 'The ajax operation failed due to a conflict');
+export function ConflictError(payload) {
+  AjaxError.call(this, payload, 'The ajax operation failed due to a conflict');
 }
 
 ConflictError.prototype = Object.create(AjaxError.prototype);
@@ -113,8 +109,8 @@ ConflictError.prototype = Object.create(AjaxError.prototype);
  * @public
  * @extends AjaxError
  */
-export function ServerError(errors) {
-  AjaxError.call(this, errors, 'Request was rejected due to server error');
+export function ServerError(payload) {
+  AjaxError.call(this, payload, 'Request was rejected due to server error');
 }
 
 ServerError.prototype = Object.create(AjaxError.prototype);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.3",
     "coveralls": "^2.11.13",
-    "ember-cli": "2.9.1",
+    "ember-cli": "2.8.0",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-code-coverage": "0.3.3",
     "ember-cli-content-security-policy": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.3",
     "coveralls": "^2.11.13",
-    "ember-cli": "2.8.0",
+    "ember-cli": "2.9.1",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-code-coverage": "0.3.3",
     "ember-cli-content-security-policy": "0.5.0",

--- a/tests/unit/mixins/ajax-request-test.js
+++ b/tests/unit/mixins/ajax-request-test.js
@@ -577,40 +577,6 @@ describe('Unit | Mixin | ajax request', function() {
       });
   });
 
-  it('it always returns error objects with status codes as strings', function() {
-    const response = [404, { 'Content-Type': 'application/json' }, ''];
-    this.server.get('/posts', () => response);
-
-    const service = new AjaxRequest();
-    return service.request('/posts')
-      .then(function() {
-        throw new Error('success handler should not be called');
-      })
-      .catch(function(result) {
-        expect(result.errors[0].status).to.equal('404');
-      });
-  });
-
-  it('it coerces payload error response status codes to strings', function() {
-    const body = {
-      errors: [
-        { status: 403, message: 'Permission Denied' }
-      ]
-    };
-    const response = [403, { 'Content-Type': 'application/json' }, JSON.stringify(body)];
-    this.server.get('/posts', () => response);
-
-    const service = new AjaxRequest();
-    return service.request('/posts')
-      .then(function() {
-        throw new Error('success handler should not be called');
-      })
-      .catch(function(result) {
-        expect(result.errors[0].status).to.equal('403');
-        expect(result.errors[0].message).to.equal('Permission Denied');
-      });
-  });
-
   it('it throws an error when the user tries to use `.get` to make a request', function() {
     const service = new AjaxRequest();
     service.set('someProperty', 'foo');
@@ -917,7 +883,7 @@ describe('Unit | Mixin | ajax request', function() {
         })
         .catch(function(reason) {
           expect(isTimeoutError(reason)).to.be.ok;
-          expect(reason.errors && typeOf(reason.errors) === 'array').to.be.ok;
+          expect(reason.payload).to.be.null;
         });
     });
 
@@ -931,9 +897,15 @@ describe('Unit | Mixin | ajax request', function() {
           })
           .catch(function(reason) {
             expect(reason instanceof errorClass).to.be.ok;
-            expect(reason.errors && typeOf(reason.errors) === 'array').to.be.ok;
-            expect(reason.errors[0].id).to.equal(1);
-            expect(reason.errors[0].message).to.equal('error description');
+            expect(reason.payload).to.not.be.undefined;
+
+            let {
+              errors
+            } = reason.payload;
+
+            expect(errors && typeOf(errors) === 'array').to.be.ok;
+            expect(errors[0].id).to.equal(1);
+            expect(errors[0].message).to.equal('error description');
           });
       });
     }

--- a/tests/unit/mixins/ajax-request-test.js
+++ b/tests/unit/mixins/ajax-request-test.js
@@ -881,6 +881,32 @@ describe('Unit | Mixin | ajax request', function() {
     });
   });
 
+  describe('[ISSUE 175] error property deprecation', function() {
+    beforeEach(function() {
+      // eslint-disable-next-line
+      Ember.ENV.RAISE_ON_DEPRECATION = true;
+    });
+
+    afterEach(function() {
+      // eslint-disable-next-line
+      Ember.ENV.RAISE_ON_DEPRECATION = false;
+    });
+
+    it('notifies', function() {
+      this.server.get('/posts', jsonFactory(404, { errors: [{ id: 1, message: 'error description' }] }));
+      const service = new AjaxRequest();
+      return service.request('/posts')
+        .then(function() {
+          throw new Error('success handler should not be called');
+        })
+        .catch(function(reason) {
+          expect(function() {
+            reason.errors;
+          }).to.throws('This property will be removed in ember-ajax 3.0.0. Please use `payload` going forward. Note the attached URL for details.');
+        });
+    });
+  });
+
   describe('error handlers', function() {
     it('handles a TimeoutError correctly', function() {
       this.server.get('/posts', jsonFactory(200), 2);


### PR DESCRIPTION
This breaking change accomplishes a few things:

* Deprecates the AjaxError#errors property. Going forward we'll do much
  less with errors, and instead simply provide the payload from the
  server's error response. The payload will be accessible via the
  #payload property.
* Refactors Ajax Error, and friends, into ES6 classes. This is
  potentially a breaking change as we no longer inherit from
  Ember.Error.

Closes #175