### PR TITLE
Use `\n` as CLRF in FastBoot mode to parse headers

### DIFF
--- a/addon/utils/parse-response-headers.js
+++ b/addon/utils/parse-response-headers.js
@@ -1,4 +1,6 @@
-const CLRF = '\u000d\u000a';
+import isFastBoot from './is-fastboot';
+
+const CLRF = isFastBoot ? '\n' : '\u000d\u000a';
 
 export default function parseResponseHeaders(headersString) {
   let headers = {};


### PR DESCRIPTION
fix #162
