### PR TITLE
Case-insensitive header matching

### DIFF
--- a/addon/mixins/ajax-request.js
+++ b/addon/mixins/ajax-request.js
@@ -618,7 +618,7 @@ export default Mixin.create({
     let shortenedPayload;
     const payloadContentType = getHeader(headers, 'Content-Type') || 'Empty Content-Type';
 
-    if (payloadContentType === 'text/html' && payload.length > 250) {
+    if (payloadContentType.toLowerCase() === 'text/html' && payload.length > 250) {
       shortenedPayload = '[Omitted Lengthy HTML]';
     } else {
       shortenedPayload = JSON.stringify(payload);

--- a/addon/mixins/ajax-request.js
+++ b/addon/mixins/ajax-request.js
@@ -43,13 +43,13 @@ const {
   testing,
   warn
 } = Ember;
-const JSONAPIContentType = 'application/vnd.api+json';
+const JSONAPIContentType = /^application\/vnd\.api\+json/i;
 
 function isJSONAPIContentType(header) {
   if (isNone(header)) {
     return false;
   }
-  return header.indexOf(JSONAPIContentType) === 0;
+  return !!header.match(JSONAPIContentType);
 }
 
 function startsWithSlash(string) {

--- a/addon/mixins/ajax-request.js
+++ b/addon/mixins/ajax-request.js
@@ -22,6 +22,7 @@ import {
   isSuccess
 } from '../errors';
 import parseResponseHeaders from '../utils/parse-response-headers';
+import getHeader from '../utils/get-header';
 import { RequestURL } from '../utils/url-helpers';
 import ajax from '../utils/ajax';
 
@@ -236,7 +237,7 @@ export default Mixin.create({
       url: hash.url
     };
 
-    if (isJSONAPIContentType(hash.headers['Content-Type']) && requestData.type !== 'GET') {
+    if (isJSONAPIContentType(getHeader(hash.headers, 'Content-Type')) && requestData.type !== 'GET') {
       if (typeof hash.data === 'object') {
         hash.data = JSON.stringify(hash.data);
       }
@@ -615,7 +616,7 @@ export default Mixin.create({
    */
   generateDetailedMessage(status, headers, payload, requestData) {
     let shortenedPayload;
-    const payloadContentType = headers['Content-Type'] || 'Empty Content-Type';
+    const payloadContentType = getHeader(headers, 'Content-Type') || 'Empty Content-Type';
 
     if (payloadContentType === 'text/html' && payload.length > 250) {
       shortenedPayload = '[Omitted Lengthy HTML]';

--- a/addon/utils/get-header.js
+++ b/addon/utils/get-header.js
@@ -16,7 +16,7 @@ export default function getHeader(headers, name) {
     return; // ask for nothing, get nothing.
   }
 
-  let matchedKey = A(Object.keys(headers)).find((key) => {
+  const matchedKey = A(Object.keys(headers)).find((key) => {
     return key.toLowerCase() === name.toLowerCase();
   });
 

--- a/addon/utils/get-header.js
+++ b/addon/utils/get-header.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+
+const { A, isNone } = Ember;
+
+/**
+ * Do a case-insensitive lookup of an HTTP header
+ *
+ * @function getHeader
+ * @private
+ * @param {Object} headers
+ * @param {string} name
+ * @return {string}
+ */
+export default function getHeader(headers, name) {
+  if (isNone(headers) || isNone(name)) {
+    return; // ask for nothing, get nothing.
+  }
+
+  let matchedKey = A(Object.keys(headers)).find((key) => {
+    return key.toLowerCase() === name.toLowerCase();
+  });
+
+  return headers[matchedKey];
+}

--- a/tests/unit/utils/get-header-test.js
+++ b/tests/unit/utils/get-header-test.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import getHeader from 'ember-ajax/utils/get-header';
 import { describe, it } from 'mocha';
 import { assert } from 'chai';

--- a/tests/unit/utils/get-header-test.js
+++ b/tests/unit/utils/get-header-test.js
@@ -1,0 +1,44 @@
+/* jshint expr:true */
+import getHeader from 'ember-ajax/utils/get-header';
+import { describe, it } from 'mocha';
+import { assert } from 'chai';
+
+const { equal } = assert;
+
+describe('getHeader', function() {
+  it('returns undefined when headers are undefined', function() {
+    let header = getHeader(undefined);
+
+    equal(header, undefined, 'undefined is returned');
+  });
+
+  it('returns undefined when name is undefined', function() {
+    let header = getHeader({}, undefined);
+
+    equal(header, undefined, 'undefined is returned');
+  });
+
+  it('matches result given by direct object access', function() {
+    let headers = {
+      'Content-Encoding': 'gzip',
+      'content-type': 'application/json; charset=utf-8',
+      'date': 'Fri, 12 Feb 2016 19:21:00 GMT'
+    };
+
+    equal(getHeader(headers, 'Content-Encoding'), headers['Content-Encoding'], 'matches direct object access');
+    equal(getHeader(headers, 'content-type'), headers['content-type'], 'matches direct object access');
+    equal(getHeader(headers, 'date'), headers.date, 'matches direct object access');
+  });
+
+  it('performs case-insensitive lookup', function() {
+    let headers = {
+      'Content-Encoding': 'gzip',
+      'content-type': 'application/json; charset=utf-8',
+      'date': 'Fri, 12 Feb 2016 19:21:00 GMT'
+    };
+
+    equal(getHeader(headers, 'CoNtEnT-EnCoDiNg'), headers['Content-Encoding'], 'matches case-insensitive header');
+    equal(getHeader(headers, 'Content-Type'), headers['content-type'], 'matches case-insensitive header');
+    equal(getHeader(headers, 'DATE'), headers.date, 'matches case-insensitive header');
+  });
+});

--- a/tests/unit/utils/get-header-test.js
+++ b/tests/unit/utils/get-header-test.js
@@ -6,19 +6,19 @@ const { equal } = assert;
 
 describe('getHeader', function() {
   it('returns undefined when headers are undefined', function() {
-    let header = getHeader(undefined);
+    const header = getHeader(undefined);
 
     equal(header, undefined, 'undefined is returned');
   });
 
   it('returns undefined when name is undefined', function() {
-    let header = getHeader({}, undefined);
+    const header = getHeader({}, undefined);
 
     equal(header, undefined, 'undefined is returned');
   });
 
   it('matches result given by direct object access', function() {
-    let headers = {
+    const headers = {
       'Content-Encoding': 'gzip',
       'content-type': 'application/json; charset=utf-8',
       'date': 'Fri, 12 Feb 2016 19:21:00 GMT'
@@ -30,7 +30,7 @@ describe('getHeader', function() {
   });
 
   it('performs case-insensitive lookup', function() {
-    let headers = {
+    const headers = {
       'Content-Encoding': 'gzip',
       'content-type': 'application/json; charset=utf-8',
       'date': 'Fri, 12 Feb 2016 19:21:00 GMT'

--- a/tests/unit/utils/get-header-test.js
+++ b/tests/unit/utils/get-header-test.js
@@ -1,20 +1,18 @@
 import getHeader from 'ember-ajax/utils/get-header';
 import { describe, it } from 'mocha';
-import { assert } from 'chai';
-
-const { equal } = assert;
+import { expect } from 'chai';
 
 describe('getHeader', function() {
   it('returns undefined when headers are undefined', function() {
     const header = getHeader(undefined);
 
-    equal(header, undefined, 'undefined is returned');
+    expect(header).to.equal(undefined, 'undefined is returned');
   });
 
   it('returns undefined when name is undefined', function() {
     const header = getHeader({}, undefined);
 
-    equal(header, undefined, 'undefined is returned');
+    expect(header).to.equal(undefined, 'undefined is returned');
   });
 
   it('matches result given by direct object access', function() {
@@ -24,9 +22,9 @@ describe('getHeader', function() {
       'date': 'Fri, 12 Feb 2016 19:21:00 GMT'
     };
 
-    equal(getHeader(headers, 'Content-Encoding'), headers['Content-Encoding'], 'matches direct object access');
-    equal(getHeader(headers, 'content-type'), headers['content-type'], 'matches direct object access');
-    equal(getHeader(headers, 'date'), headers.date, 'matches direct object access');
+    expect(getHeader(headers, 'Content-Encoding')).to.equal(headers['Content-Encoding'], 'matches direct object access');
+    expect(getHeader(headers, 'content-type')).to.equal(headers['content-type'], 'matches direct object access');
+    expect(getHeader(headers, 'date')).to.equal(headers.date, 'matches direct object access');
   });
 
   it('performs case-insensitive lookup', function() {
@@ -36,8 +34,8 @@ describe('getHeader', function() {
       'date': 'Fri, 12 Feb 2016 19:21:00 GMT'
     };
 
-    equal(getHeader(headers, 'CoNtEnT-EnCoDiNg'), headers['Content-Encoding'], 'matches case-insensitive header');
-    equal(getHeader(headers, 'Content-Type'), headers['content-type'], 'matches case-insensitive header');
-    equal(getHeader(headers, 'DATE'), headers.date, 'matches case-insensitive header');
+    expect(getHeader(headers, 'CoNtEnT-EnCoDiNg')).to.equal(headers['Content-Encoding'], 'matches case-insensitive header');
+    expect(getHeader(headers, 'Content-Type')).to.equal(headers['content-type'], 'matches case-insensitive header');
+    expect(getHeader(headers, 'DATE')).to.equal(headers.date, 'matches case-insensitive header');
   });
 });


### PR DESCRIPTION
Closes #184 -- tests included, all passing on my end. Covers everything on [the checklist](https://github.com/ember-cli/ember-ajax/pull/119#issuecomment-226352391), plus a bit more.

I opted for a regex check for the JSON API content type solely to get rid of `indexOf`, because I am a silly person. 
