### PR TITLE
Tighten eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,10 @@ module.exports = {
     'browser': true
   },
   rules: {
-    'ember-suave/no-const-outside-module-scope': 'off'
+    // Ember Suave
+    'ember-suave/no-const-outside-module-scope': 'off',
+
+    // Built-In Rules
+    'prefer-const': 'error'
   }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,8 @@
 module.exports = {
-  extends: 'plugin:ember-suave/recommended',
+  extends: [
+    'eslint:recommended',
+    'plugin:ember-suave/recommended'
+  ],
   root: true,
   parserOptions: {
     ecmaVersion: 6,

--- a/addon/errors.js
+++ b/addon/errors.js
@@ -280,6 +280,6 @@ export function isServerError(error) {
  * @return {Boolean}
  */
 export function isSuccess(status) {
-  let s = parseInt(status, 10);
+  const s = parseInt(status, 10);
   return s >= 200 && s < 300 || s === 304;
 }

--- a/addon/mixins/ajax-request.js
+++ b/addon/mixins/ajax-request.js
@@ -60,7 +60,7 @@ function defineDeprecatedErrorsProperty(error, errors) {
         }
       );
 
-      let defaultError = {
+      const defaultError = {
         title: 'Ajax Error',
         detail: this.message
       };
@@ -273,7 +273,7 @@ export default Mixin.create({
 
     return new Promise((resolve, reject) => {
       hash.success = (payload, textStatus, jqXHR) => {
-        let response = this.handleResponse(
+        const response = this.handleResponse(
           jqXHR.status,
           parseResponseHeaders(jqXHR.getAllResponseHeaders()),
           payload,
@@ -291,8 +291,8 @@ export default Mixin.create({
 
       hash.error = (jqXHR, textStatus, errorThrown) => {
         runInDebug(function() {
-          let message = `The server returned an empty string for ${requestData.type} ${requestData.url}, which cannot be parsed into a valid JSON. Return either null or {}.`;
-          let validJSONString = !(textStatus === 'parsererror' && jqXHR.responseText === '');
+          const message = `The server returned an empty string for ${requestData.type} ${requestData.url}, which cannot be parsed into a valid JSON. Return either null or {}.`;
+          const validJSONString = !(textStatus === 'parsererror' && jqXHR.responseText === '');
           warn(message, validJSONString, {
             id: 'ds.adapter.returned-empty-string-as-JSON'
           });
@@ -559,7 +559,7 @@ export default Mixin.create({
     } else if (this.isServerError(status, headers, payload)) {
       error = new ServerError(payload);
     } else {
-      let detailedMessage = this.generateDetailedMessage(
+      const detailedMessage = this.generateDetailedMessage(
         status,
         headers,
         payload,
@@ -569,7 +569,7 @@ export default Mixin.create({
       error = new AjaxError(payload, detailedMessage);
     }
 
-    let errors = this.normalizeErrorResponse(status, headers, payload);
+    const errors = this.normalizeErrorResponse(status, headers, payload);
 
     defineDeprecatedErrorsProperty(error, errors);
 
@@ -853,7 +853,7 @@ export default Mixin.create({
     if (isArray(payload.errors)) {
       return payload.errors.map(function(error) {
         if (isObject(error)) {
-          let ret = merge({}, error);
+          const ret = merge({}, error);
           ret.status = `${error.status}`;
           return ret;
         } else {

--- a/addon/mixins/ajax-request.js
+++ b/addon/mixins/ajax-request.js
@@ -27,7 +27,6 @@ import { isFullURL, parseURL, haveSameHost } from 'ember-ajax/-private/utils/url
 import ajax from 'ember-ajax/utils/ajax';
 
 const {
-  $,
   A,
   Error: EmberError,
   Logger,

--- a/addon/mixins/ajax-support.js
+++ b/addon/mixins/ajax-support.js
@@ -35,7 +35,7 @@ export default Mixin.create({
   headers: alias('ajaxService.headers'),
 
   ajax(url, type, options = {}) {
-    let augmentedOptions = this.ajaxOptions(...arguments);
+    const augmentedOptions = this.ajaxOptions(...arguments);
 
     return this.get('ajaxService').request(url, augmentedOptions);
   }

--- a/addon/mixins/ajax-support.js
+++ b/addon/mixins/ajax-support.js
@@ -34,7 +34,7 @@ export default Mixin.create({
    */
   headers: alias('ajaxService.headers'),
 
-  ajax(url, type, options = {}) {
+  ajax(url) {
     const augmentedOptions = this.ajaxOptions(...arguments);
 
     return this.get('ajaxService').request(url, augmentedOptions);

--- a/tests/acceptance/ember-data-integration-test.js
+++ b/tests/acceptance/ember-data-integration-test.js
@@ -69,7 +69,7 @@ describe('Acceptance | ember data integration', function() {
 
   it('respects ajaxOptions on the target adapter', function() {
     server.get('api/posts/1', function({ requestHeaders }) {
-      let xSillyHeader = requestHeaders['X-Silly-Option'];
+      const xSillyHeader = requestHeaders['X-Silly-Option'];
       equal(xSillyHeader, 'Hi!');
 
       return jsonResponse(200, {

--- a/tests/dummy/app/adapters/application.js
+++ b/tests/dummy/app/adapters/application.js
@@ -7,7 +7,7 @@ export default JSONAPIAdapter.extend(AjaxServiceSupport, {
   namespace: 'api',
 
   ajaxOptions() {
-    let hash = this._super(...arguments);
+    const hash = this._super(...arguments);
 
     hash.headers = {
       'X-Silly-Option': 'Hi!'

--- a/tests/dummy/app/components/ajax-get.js
+++ b/tests/dummy/app/components/ajax-get.js
@@ -7,7 +7,7 @@ export default Component.extend({
   ajax: inject.service(),
   actions: {
     load() {
-      let url = this.get('url');
+      const url = this.get('url');
       return this.get('ajax').request(url)
         .then((data) => {
           this.setProperties({

--- a/tests/integration/components/async-widget-test.js
+++ b/tests/integration/components/async-widget-test.js
@@ -39,10 +39,10 @@ describeComponent(
       const authToken = 'foo';
       this.register('service:session', Service.extend({ authToken }));
 
-      let receivedHeaders = [];
+      const receivedHeaders = [];
       this.register('service:fajax', AjaxService.extend({
         options() {
-          let options = this._super(...arguments);
+          const options = this._super(...arguments);
           Object.keys(options.headers).forEach((key) => {
             receivedHeaders.push([key, options.headers[key]]);
           });
@@ -52,7 +52,7 @@ describeComponent(
         headers: computed('session.authToken', {
           get() {
             const headers = {};
-            let authToken = this.get('session.authToken');
+            const authToken = this.get('session.authToken');
             if (authToken) {
               headers.authToken = authToken;
             }

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,5 +1,8 @@
+import Ember from 'ember';
 import resolver from './helpers/resolver';
 import { setResolver } from 'ember-mocha';
+
+const { $ } = Ember;
 
 setResolver(resolver);
 

--- a/tests/unit/mixins/ajax-request-test.js
+++ b/tests/unit/mixins/ajax-request-test.js
@@ -243,8 +243,8 @@ describe('Unit | Mixin | ajax request', function() {
 
   it('request() promise label is correct', function() {
     const service = new AjaxRequest();
-    let url = '/posts';
-    let data = {
+    const url = '/posts';
+    const data = {
       type: 'POST',
       data: {
         post: { title: 'Title', description: 'Some description.' }
@@ -267,7 +267,7 @@ describe('Unit | Mixin | ajax request', function() {
     const url = '/posts';
     const title = 'Title';
     const description = 'Some description.';
-    let options = {
+    const options = {
       data: {
         post: { title, description }
       }
@@ -759,7 +759,7 @@ describe('Unit | Mixin | ajax request', function() {
     ];
 
     [NamespaceLeadingSlash, NamespaceTrailingSlash, NamespaceTwoSlash, NamespaceNoSlash].forEach((Klass) => {
-      let req = new Klass();
+      const req = new Klass();
 
       hosts.forEach((exampleHost) => {
         const { host } = exampleHost;
@@ -907,9 +907,7 @@ describe('Unit | Mixin | ajax request', function() {
             expect(reason instanceof errorClass).to.be.ok;
             expect(reason.payload).to.not.be.undefined;
 
-            let {
-              errors
-            } = reason.payload;
+            const { errors } = reason.payload;
 
             expect(errors && typeOf(errors) === 'array').to.be.ok;
             expect(errors[0].id).to.equal(1);


### PR DESCRIPTION
Due to changes in the Ember Suave config, we needed to import the `eslint:recommended` config as well. Also, ensure that we require `const` when variables don't change.

Based on the `v3.0.0` branch so that we're not cleaning up files that are no longer used.