### PR TITLE
Add XHR property to promises

### DIFF
--- a/addon/-private/promise.js
+++ b/addon/-private/promise.js
@@ -1,0 +1,29 @@
+import Ember from 'ember';
+
+const { RSVP: { Promise } } = Ember;
+
+/**
+ * AJAX Promise
+ *
+ * Sub-class of RSVP Promise that passes the XHR property on to the
+ * child promise
+ *
+ * @extends RSVP.Promise
+ * @private
+ */
+export default class AJAXPromise extends Promise {
+
+  /**
+   * Overriding `.then` to add XHR to child promise
+   *
+   * @public
+   * @return {AJAXPromise} child promise
+   */
+  then() {
+    const child = super.then(...arguments);
+
+    child.xhr = this.xhr;
+
+    return child;
+  }
+}

--- a/addon/mixins/ajax-request.js
+++ b/addon/mixins/ajax-request.js
@@ -296,7 +296,7 @@ export default Mixin.create({
             run.join(null, resolve, { payload, textStatus, jqXHR, response });
           }
         })
-        .error((jqXHR, textStatus, errorThrown) => {
+        .fail((jqXHR, textStatus, errorThrown) => {
           runInDebug(function() {
             let message = `The server returned an empty string for ${requestData.type} ${requestData.url}, which cannot be parsed into a valid JSON. Return either null or {}.`;
             let validJSONString = !(textStatus === 'parsererror' && jqXHR.responseText === '');

--- a/tests/unit/-private/promise-test.js
+++ b/tests/unit/-private/promise-test.js
@@ -1,0 +1,30 @@
+import { describe, it, beforeEach } from 'mocha';
+import { expect } from 'chai';
+
+import AJAXPromise from 'ember-ajax/-private/promise';
+
+describe('Unit | AJAXPromise Class', function() {
+  it('propigates the `xhr` property after calling `.then`', function() {
+    const promise = AJAXPromise.resolve('foo');
+    promise.xhr = { foo: 'bar' };
+
+    const childPromise = promise.then((d) => d);
+    expect(childPromise.xhr).to.equal(promise.xhr);
+  });
+
+  it('propigates the `xhr` property after calling `.catch`', function() {
+    const promise = AJAXPromise.resolve('foo');
+    promise.xhr = { foo: 'bar' };
+
+    const childPromise = promise.catch((d) => d);
+    expect(childPromise.xhr).to.equal(promise.xhr);
+  });
+
+  it('propigates the `xhr` property after calling `.finally`', function() {
+    const promise = AJAXPromise.resolve('foo');
+    promise.xhr = { foo: 'bar' };
+
+    const childPromise = promise.finally((d) => d);
+    expect(childPromise.xhr).to.equal(promise.xhr);
+  });
+});

--- a/tests/unit/mixins/ajax-request-test.js
+++ b/tests/unit/mixins/ajax-request-test.js
@@ -987,13 +987,11 @@ describe('Unit | Mixin | ajax request', function() {
       expect(promise.xhr).to.be.ok;
     });
 
+    // Note: the `.catch` handler _must_ be set up before the request is aborted
+    // Without that, the rejection will be treated as un-handled
     it('can be used to abort the request', function() {
       const ajax = new AjaxRequest();
-      const promise = ajax.request('/foo');
-
-      promise.xhr.abort();
-
-      return promise
+      const promise = ajax.request('/foo')
         .then((response) => {
           // Ensure that this code is not executed
           expect(false).to.be.ok;
@@ -1001,6 +999,10 @@ describe('Unit | Mixin | ajax request', function() {
         .catch((error) => {
           expect(error).to.be.instanceOf(AbortError);
         });
+
+      promise.xhr.abort();
+
+      return promise;
     });
 
     describe('passing the XHR to child promises', function() {


### PR DESCRIPTION
A long-standing (_really_ long-standing) request of `ember-ajax` has been to provide a better way to access the XHR object created by a request without needing to use `.raw`, which only gives you the object after the fact.

This PR adds a `.xhr` object to the promise returned by making a request that can be used to inspect or manipulate the request.  This is especially useful for aborting the request after it has been kicked off, which previously has been impossible.

Closes #67 