### PR TITLE
Clone options object before modifying it

### DIFF
--- a/addon/mixins/ajax-request.js
+++ b/addon/mixins/ajax-request.js
@@ -452,7 +452,7 @@ export default Mixin.create({
    * @return {Object}
    */
   options(url, options = {}) {
-    options = Ember.merge({}, options);
+    options = merge({}, options);
     options.url = this._buildURL(url, options);
     options.type = options.type || 'GET';
     options.dataType = options.dataType || 'json';

--- a/addon/mixins/ajax-request.js
+++ b/addon/mixins/ajax-request.js
@@ -452,6 +452,7 @@ export default Mixin.create({
    * @return {Object}
    */
   options(url, options = {}) {
+    options = Ember.merge({}, options);
     options.url = this._buildURL(url, options);
     options.type = options.type || 'GET';
     options.dataType = options.dataType || 'json';


### PR DESCRIPTION
The `options` object could be [frozen](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze) and therefore not modifiable. It is safer to work with a clone of it. This PR does just that.

If for some reason it is not acceptable to assign to the `options` argument, let me know and I can modify this accordingly.