### PR TITLE
Better URL detection for .get error

### DIFF
--- a/addon/mixins/ajax-request.js
+++ b/addon/mixins/ajax-request.js
@@ -414,7 +414,7 @@ export default Mixin.create({
    * @public
    */
   get(url) {
-    if (arguments.length > 1 || url.charAt(0) === '/') {
+    if (arguments.length > 1 || url.indexOf('/') !== -1) {
       throw new EmberError('It seems you tried to use `.get` to make a request! Use the `.request` method instead.');
     }
     return this._super(...arguments);


### PR DESCRIPTION
I tried doing `.get('some/url')` and was scratching my head for a while..

And that I know of people don't do `object.get('my/property/with/slashes')`