### PR TITLE
errors: Recognize HTTP status 0 as AbortError

### DIFF
--- a/addon/errors.js
+++ b/addon/errors.js
@@ -235,7 +235,11 @@ export function isTimeoutError(error) {
  * @return {Boolean}
  */
 export function isAbortError(error) {
-  return error instanceof AbortError;
+  if (isAjaxError(error)) {
+    return error instanceof AbortError;
+  } else {
+    return error === 0;
+  }
 }
 
 /**

--- a/tests/unit/errors-test.js
+++ b/tests/unit/errors-test.js
@@ -180,6 +180,10 @@ describe('unit/errors-test - AjaxError', function() {
   });
 
   describe('isAbortError', function() {
+    it('detects error code correctly', function() {
+      ok(isAbortError(0));
+    });
+
     it('detects error class correctly', function() {
       const error = new AbortError();
       ok(isAbortError(error));


### PR DESCRIPTION
This only happens when the browser itself is aborting the request due to e.g. a page reload, which seems impossible to test within our test framework.

Resolves https://github.com/ember-cli/ember-ajax/issues/195

/cc @oscarni @XaserAcheron 