### PR TITLE
Add Ember 1.13 to Ember Try config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
     - $HOME/.yarn-cache
 
 env:
-  # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
+  - EMBER_TRY_SCENARIO=ember-1.13
   - EMBER_TRY_SCENARIO=ember-lts-2.4
   - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-release COVERAGE=true

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -3,6 +3,22 @@
 module.exports = {
   scenarios: [
     {
+      name: 'ember-1.13',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#1.13.13'
+        },
+        resolutions: {
+          'ember': '1.13.13'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
       name: 'ember-lts-2.4',
       bower: {
         dependencies: {


### PR DESCRIPTION
Since we advertise Ember v1.13 compatibility, we should run Travis against it as well to make sure it really works.