### PR TITLE
make sure contentType is a string before running a regex match

### DIFF
--- a/addon/mixins/ajax-request.js
+++ b/addon/mixins/ajax-request.js
@@ -71,7 +71,7 @@ function defineDeprecatedErrorsProperty(error, errors) {
 }
 
 function isJSONContentType(header) {
-  if (isNone(header)) {
+  if (!isString(header)) {
     return false;
   }
   return !!header.match(JSONContentType);


### PR DESCRIPTION
This caused issues when we are doing `POST` requests for uploads which we may or may not specify a `contentType`. If `contentType` is false it still tries to run `.match` and you get an error.