### PR TITLE
Simplify `normalizeErrorResponse`

### DIFF
--- a/addon/mixins/legacy/normalize-error-response.js
+++ b/addon/mixins/legacy/normalize-error-response.js
@@ -1,0 +1,104 @@
+import Ember from 'ember';
+
+const {
+  Mixin,
+  isArray,
+  isNone,
+  merge
+} = Ember;
+
+function isObject(object) {
+  return typeof object === 'object';
+}
+
+function isString(object) {
+  return typeof object === 'string';
+}
+
+export default Mixin.create({
+  /**
+   * Normalize the error from the server into the same format
+   *
+   * The format we normalize to is based on the JSON API specification.  The
+   * return value should be an array of objects that match the format they
+   * describe. More details about the object format can be found
+   * [here](http://jsonapi.org/format/#error-objects)
+   *
+   * The basics of the format are as follows:
+   *
+   * ```javascript
+   * [
+   *   {
+   *     status: 'The status code for the error',
+   *     title: 'The human-readable title of the error'
+   *     detail: 'The human-readable details of the error'
+   *   }
+   * ]
+   * ```
+   *
+   * In cases where the server returns an array, then there should be one item
+   * in the array for each of the payload.  If your server returns a JSON API
+   * formatted payload already, it will just be returned directly.
+   *
+   * If your server returns something other than a JSON API format, it's
+   * suggested that you override this method to convert your own errors into the
+   * one described above.
+   *
+   * @method normalizeErrorResponse
+   * @private
+   * @param  {Number} status
+   * @param  {Object} headers
+   * @param  {Object} payload
+   * @return {Array} An array of JSON API-formatted error objects
+   */
+  normalizeErrorResponse(status, headers, payload) {
+    payload = isNone(payload) ? {} : payload;
+
+    if (isArray(payload.errors)) {
+      return payload.errors.map(function(error) {
+        if (isObject(error)) {
+          let ret = merge({}, error);
+          ret.status = `${error.status}`;
+          return ret;
+        } else {
+          return {
+            status: `${status}`,
+            title: error
+          };
+        }
+      });
+    } else if (isArray(payload)) {
+      return payload.map(function(error) {
+        if (isObject(error)) {
+          return {
+            status: `${status}`,
+            title: error.title || 'The backend responded with an error',
+            detail: error
+          };
+        } else {
+          return {
+            status: `${status}`,
+            title: `${error}`
+          };
+        }
+      });
+    } else {
+      if (isString(payload)) {
+        return [
+          {
+            status: `${status}`,
+            title: payload
+          }
+        ];
+      } else {
+        return [
+          {
+            status: `${status}`,
+            title: payload.title || 'The backend responded with an error',
+            detail: payload
+          }
+        ];
+      }
+    }
+  }
+});

--- a/tests/acceptance/ajax-get-test.js
+++ b/tests/acceptance/ajax-get-test.js
@@ -53,7 +53,7 @@ describe('Acceptance | ajax-get component', function() {
     click('button:contains(Load Data)');
 
     andThen(function() {
-      expect(find('.ajax-get .error').text()).to.equal(errorMessage);
+      expect(find('.ajax-get .error').text().trim()).to.equal(errorMessage);
     });
   });
 });

--- a/tests/dummy/app/components/ajax-get.js
+++ b/tests/dummy/app/components/ajax-get.js
@@ -16,7 +16,7 @@ export default Component.extend({
           });
         })
         .catch((error) => {
-          this.set('errors', error.errors);
+          this.set('error', error.payload);
         });
     }
   }

--- a/tests/dummy/app/templates/components/ajax-get.hbs
+++ b/tests/dummy/app/templates/components/ajax-get.hbs
@@ -1,9 +1,7 @@
-{{#if errors}}
-  <ul class="errors">
-  {{#each errors as |error|}}
-    <li class="error">{{error.title}}</li>
-  {{/each}}
-  </ul>
+{{#if error}}
+  <p class="error">
+    {{error}}
+  </p>
 {{else}}
   {{yield (if isLoaded data (action 'load')) isLoaded}}
 {{/if}}

--- a/tests/unit/mixins/ajax-request-test.js
+++ b/tests/unit/mixins/ajax-request-test.js
@@ -729,70 +729,6 @@ describe('Unit | Mixin | ajax request', function() {
     });
   });
 
-  it('normalizes errors into the appropriate format', function() {
-    const service = new AjaxRequest();
-
-    const jsonApiError = service.normalizeErrorResponse(400, {}, {
-      errors: [
-        { status: 400, title: 'Foo' },
-        { status: 400, title: 'Foo' }
-      ]
-    });
-    expect(jsonApiError).to.deep.equal([
-        { status: '400', title: 'Foo' },
-        { status: '400', title: 'Foo' }
-    ]);
-
-    const payloadWithErrorStrings = service.normalizeErrorResponse(400, {}, {
-      errors: [
-        'This is an error',
-        'This is another error'
-      ]
-    });
-    expect(payloadWithErrorStrings).to.deep.equal([
-      { status: '400', title: 'This is an error' },
-      { status: '400', title: 'This is another error' }
-    ]);
-
-    const payloadArrayOfObjects = service.normalizeErrorResponse(400, {}, [
-      { status: 400, title: 'Foo' },
-      { status: 400, title: 'Bar' }
-    ]);
-    expect(payloadArrayOfObjects).to.deep.equal([
-      { status: '400', title: 'Foo', detail: { status: 400, title: 'Foo' } },
-      { status: '400', title: 'Bar', detail: { status: 400, title: 'Bar' } }
-    ]);
-
-    const payloadArrayOfStrings = service.normalizeErrorResponse(400, {}, [
-      'Foo', 'Bar'
-    ]);
-    expect(payloadArrayOfStrings).to.deep.equal([
-      { status: '400', title: 'Foo' },
-      { status: '400', title: 'Bar' }
-    ]);
-
-    const payloadIsString = service.normalizeErrorResponse(400, {}, 'Foo');
-    expect(payloadIsString).to.deep.equal([
-      {
-        status: '400',
-        title: 'Foo'
-      }
-    ]);
-
-    const payloadIsObject = service.normalizeErrorResponse(400, {}, {
-      title: 'Foo'
-    });
-    expect(payloadIsObject).to.deep.equal([
-      {
-        status: '400',
-        title: 'Foo',
-        detail: {
-          title: 'Foo'
-        }
-      }
-    ]);
-  });
-
   describe('URL building', function() {
     class NamespaceLeadingSlash extends AjaxRequest {
       static get slashType() {
@@ -929,32 +865,6 @@ describe('Unit | Mixin | ajax request', function() {
       .then((value) => {
         expect(value).to.deep.equal({ foo: 'bar' });
       });
-    });
-  });
-
-  describe('[ISSUE 175] error property deprecation', function() {
-    beforeEach(function() {
-      // eslint-disable-next-line
-      Ember.ENV.RAISE_ON_DEPRECATION = true;
-    });
-
-    afterEach(function() {
-      // eslint-disable-next-line
-      Ember.ENV.RAISE_ON_DEPRECATION = false;
-    });
-
-    it('notifies', function() {
-      this.server.get('/posts', jsonFactory(404, { errors: [{ id: 1, message: 'error description' }] }));
-      const service = new AjaxRequest();
-      return service.request('/posts')
-        .then(function() {
-          throw new Error('success handler should not be called');
-        })
-        .catch(function(reason) {
-          expect(function() {
-            reason.errors;
-          }).to.throws('This property will be removed in ember-ajax 3.0.0. Please use `payload` going forward. Note the attached URL for details.');
-        });
     });
   });
 

--- a/tests/unit/mixins/legacy/normalize-error-response-test.js
+++ b/tests/unit/mixins/legacy/normalize-error-response-test.js
@@ -1,0 +1,73 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import Ember from 'ember';
+import LegacyNormalizeErrorResponseMixin from 'ember-ajax/mixins/legacy/normalize-error-response';
+
+const { Object: EmberObject } = Ember;
+const AjaxRequest = EmberObject.extend(LegacyNormalizeErrorResponseMixin);
+
+describe('Unit | Mixin | legacy/normalize error response', function() {
+  it('formats the error response according to the legacy format', function() {
+    const service = new AjaxRequest();
+
+    const jsonApiError = service.normalizeErrorResponse(400, {}, {
+      errors: [
+        { status: 400, title: 'Foo' },
+        { status: 400, title: 'Foo' }
+      ]
+    });
+    expect(jsonApiError).to.deep.equal([
+        { status: '400', title: 'Foo' },
+        { status: '400', title: 'Foo' }
+    ]);
+
+    const payloadWithErrorStrings = service.normalizeErrorResponse(400, {}, {
+      errors: [
+        'This is an error',
+        'This is another error'
+      ]
+    });
+    expect(payloadWithErrorStrings).to.deep.equal([
+      { status: '400', title: 'This is an error' },
+      { status: '400', title: 'This is another error' }
+    ]);
+
+    const payloadArrayOfObjects = service.normalizeErrorResponse(400, {}, [
+      { status: 400, title: 'Foo' },
+      { status: 400, title: 'Bar' }
+    ]);
+    expect(payloadArrayOfObjects).to.deep.equal([
+      { status: '400', title: 'Foo', detail: { status: 400, title: 'Foo' } },
+      { status: '400', title: 'Bar', detail: { status: 400, title: 'Bar' } }
+    ]);
+
+    const payloadArrayOfStrings = service.normalizeErrorResponse(400, {}, [
+      'Foo', 'Bar'
+    ]);
+    expect(payloadArrayOfStrings).to.deep.equal([
+      { status: '400', title: 'Foo' },
+      { status: '400', title: 'Bar' }
+    ]);
+
+    const payloadIsString = service.normalizeErrorResponse(400, {}, 'Foo');
+    expect(payloadIsString).to.deep.equal([
+      {
+        status: '400',
+        title: 'Foo'
+      }
+    ]);
+
+    const payloadIsObject = service.normalizeErrorResponse(400, {}, {
+      title: 'Foo'
+    });
+    expect(payloadIsObject).to.deep.equal([
+      {
+        status: '400',
+        title: 'Foo',
+        detail: {
+          title: 'Foo'
+        }
+      }
+    ]);
+  });
+});


### PR DESCRIPTION
Over time, we decided that the existing `normalizeErrorResponse`
behavior tried to do way too much.  We've decided that the default
behavior should be to instead just return the error payload that the
server provides, without making modifications to it.

The old behavior can be re-introduced by including the mixin found at
`mixins/legacy/normalize-error-response`.

This also removes the deprecation warnings around the `errors` property
in favor of the replacement `payload` property.

Closes #264