### PR TITLE
Expose status codes on error objects

### DIFF
--- a/addon/mixins/ajax-request.js
+++ b/addon/mixins/ajax-request.js
@@ -555,6 +555,7 @@ export default Mixin.create({
 
       error = new AjaxError(payload, detailedMessage);
     }
+    error.status = status;
 
     return error;
   },

--- a/tests/unit/mixins/ajax-request-test.js
+++ b/tests/unit/mixins/ajax-request-test.js
@@ -573,6 +573,7 @@ describe('Unit | Mixin | ajax request', function() {
         expect(result.message).to.contain('Some error response');
         expect(result.message).to.contain('GET');
         expect(result.message).to.contain('/posts');
+        expect(result.status).to.equal(408);
       });
   });
 
@@ -589,6 +590,7 @@ describe('Unit | Mixin | ajax request', function() {
         expect(result.message).to.contain('Some error response');
         expect(result.message).to.contain('GET');
         expect(result.message).to.contain('/posts');
+        expect(result.status).to.equal(408);
       });
   });
 
@@ -879,6 +881,7 @@ describe('Unit | Mixin | ajax request', function() {
         .catch(function(reason) {
           expect(isTimeoutError(reason)).to.be.ok;
           expect(reason.payload).to.be.null;
+          expect(reason.status).to.be.undefined;
         });
     });
 
@@ -893,6 +896,7 @@ describe('Unit | Mixin | ajax request', function() {
           .catch(function(reason) {
             expect(reason instanceof errorClass).to.be.ok;
             expect(reason.payload).to.not.be.undefined;
+            expect(reason.status).to.equal(status);
 
             const { errors } = reason.payload;
 


### PR DESCRIPTION
There may be cases where applications want access to the status code that caused the error (e.g. logging/metrics, or terse user-facing error messages), so this allows them to easily get at it.

My use case is two-fold:

1. I use mixpanel to log metrics about failed requests that include the status code as a property
1. When I encounter an unhandled error, I don't want to try to communicate the distinction between "bad request", "server error", etc. -- I just want to show them a generic "Oops, my bad" message with the status code in parentheses so we have something to go on if they contact support.

Given how difficult it is to recover the status code from an error object (especially if it's just an `AjaxError` -- then the only way is to run a regex on the message ☹️ ), this seems like something worth including in the base implementation and not requiring users to subclass the service in order to get.