### PR TITLE
Expose error codes

### DIFF
--- a/addon/errors.js
+++ b/addon/errors.js
@@ -5,10 +5,11 @@ import EmberError from '@ember/error';
  * @public
  * @extends Ember.Error
  */
-export function AjaxError(payload, message = 'Ajax operation failed') {
+export function AjaxError(payload, message = 'Ajax operation failed', status) {
   EmberError.call(this, message);
 
   this.payload = payload;
+  this.status = status;
 }
 
 AjaxError.prototype = Object.create(EmberError.prototype);
@@ -19,7 +20,7 @@ AjaxError.prototype = Object.create(EmberError.prototype);
  * @extends AjaxError
  */
 export function InvalidError(payload) {
-  AjaxError.call(this, payload, 'Request was rejected because it was invalid');
+  AjaxError.call(this, payload, 'Request was rejected because it was invalid', 422);
 }
 
 InvalidError.prototype = Object.create(AjaxError.prototype);
@@ -30,7 +31,7 @@ InvalidError.prototype = Object.create(AjaxError.prototype);
  * @extends AjaxError
  */
 export function UnauthorizedError(payload) {
-  AjaxError.call(this, payload, 'Ajax authorization failed');
+  AjaxError.call(this, payload, 'Ajax authorization failed', 401);
 }
 
 UnauthorizedError.prototype = Object.create(AjaxError.prototype);
@@ -44,7 +45,8 @@ export function ForbiddenError(payload) {
   AjaxError.call(
     this,
     payload,
-    'Request was rejected because user is not permitted to perform this operation.'
+    'Request was rejected because user is not permitted to perform this operation.',
+    403
   );
 }
 
@@ -56,7 +58,7 @@ ForbiddenError.prototype = Object.create(AjaxError.prototype);
  * @extends AjaxError
  */
 export function BadRequestError(payload) {
-  AjaxError.call(this, payload, 'Request was formatted incorrectly.');
+  AjaxError.call(this, payload, 'Request was formatted incorrectly.', 400);
 }
 
 BadRequestError.prototype = Object.create(AjaxError.prototype);
@@ -67,7 +69,7 @@ BadRequestError.prototype = Object.create(AjaxError.prototype);
  * @extends AjaxError
  */
 export function NotFoundError(payload) {
-  AjaxError.call(this, payload, 'Resource was not found.');
+  AjaxError.call(this, payload, 'Resource was not found.', 404);
 }
 
 NotFoundError.prototype = Object.create(AjaxError.prototype);
@@ -78,7 +80,7 @@ NotFoundError.prototype = Object.create(AjaxError.prototype);
  * @extends AjaxError
  */
 export function TimeoutError() {
-  AjaxError.call(this, null, 'The ajax operation timed out');
+  AjaxError.call(this, null, 'The ajax operation timed out', -1);
 }
 
 TimeoutError.prototype = Object.create(AjaxError.prototype);
@@ -89,7 +91,7 @@ TimeoutError.prototype = Object.create(AjaxError.prototype);
  * @extends AjaxError
  */
 export function AbortError() {
-  AjaxError.call(this, null, 'The ajax operation was aborted');
+  AjaxError.call(this, null, 'The ajax operation was aborted', 0);
 }
 
 AbortError.prototype = Object.create(AjaxError.prototype);
@@ -100,7 +102,7 @@ AbortError.prototype = Object.create(AjaxError.prototype);
  * @extends AjaxError
  */
 export function ConflictError(payload) {
-  AjaxError.call(this, payload, 'The ajax operation failed due to a conflict');
+  AjaxError.call(this, payload, 'The ajax operation failed due to a conflict', 409);
 }
 
 ConflictError.prototype = Object.create(AjaxError.prototype);
@@ -110,8 +112,8 @@ ConflictError.prototype = Object.create(AjaxError.prototype);
  * @public
  * @extends AjaxError
  */
-export function ServerError(payload) {
-  AjaxError.call(this, payload, 'Request was rejected due to server error');
+export function ServerError(payload, status) {
+  AjaxError.call(this, payload, 'Request was rejected due to server error', status);
 }
 
 ServerError.prototype = Object.create(AjaxError.prototype);

--- a/addon/mixins/ajax-request.js
+++ b/addon/mixins/ajax-request.js
@@ -528,12 +528,11 @@ export default Mixin.create({
     // Allow overriding of error payload
     payload = this.normalizeErrorResponse(status, headers, payload);
 
-    return _createCorrectError(status, headers, payload, requestData);
+    return this._createCorrectError(status, headers, payload, requestData);
   },
 
   _createCorrectError(status, headers, payload, requestData) {
     let error;
-
 
     if (this.isUnauthorizedError(status, headers, payload)) {
       error = new UnauthorizedError(payload);

--- a/addon/mixins/ajax-request.js
+++ b/addon/mixins/ajax-request.js
@@ -551,6 +551,7 @@ export default Mixin.create({
 
       error = new AjaxError(payload, detailedMessage);
     }
+    error.status = status;
 
     return error;
   },

--- a/addon/mixins/ajax-request.js
+++ b/addon/mixins/ajax-request.js
@@ -521,14 +521,19 @@ export default Mixin.create({
    * @return {Object | AjaxError} response
    */
   handleResponse(status, headers, payload, requestData) {
-    let error;
-
     if (this.isSuccess(status, headers, payload)) {
       return payload;
     }
 
     // Allow overriding of error payload
     payload = this.normalizeErrorResponse(status, headers, payload);
+
+    return _createCorrectError(status, headers, payload, requestData);
+  },
+
+  _createCorrectError(status, headers, payload, requestData) {
+    let error;
+
 
     if (this.isUnauthorizedError(status, headers, payload)) {
       error = new UnauthorizedError(payload);
@@ -545,13 +550,12 @@ export default Mixin.create({
     } else if (this.isConflictError(status, headers, payload)) {
       error = new ConflictError(payload);
     } else if (this.isServerError(status, headers, payload)) {
-      error = new ServerError(payload);
+      error = new ServerError(payload, status);
     } else {
       const detailedMessage = this.generateDetailedMessage(status, headers, payload, requestData);
 
-      error = new AjaxError(payload, detailedMessage);
+      error = new AjaxError(payload, detailedMessage, status);
     }
-    error.status = status;
 
     return error;
   },

--- a/tests/unit/mixins/ajax-request-test.js
+++ b/tests/unit/mixins/ajax-request-test.js
@@ -570,6 +570,7 @@ describe('Unit | Mixin | ajax request', function() {
         expect(result.message).to.contain('Some error response');
         expect(result.message).to.contain('GET');
         expect(result.message).to.contain('/posts');
+        expect(result.status).to.equal(408);
       });
   });
 
@@ -587,6 +588,7 @@ describe('Unit | Mixin | ajax request', function() {
         expect(result.message).to.contain('Some error response');
         expect(result.message).to.contain('GET');
         expect(result.message).to.contain('/posts');
+        expect(result.status).to.equal(408);
       });
   });
 
@@ -883,6 +885,7 @@ describe('Unit | Mixin | ajax request', function() {
         .catch(function(reason) {
           expect(isTimeoutError(reason)).to.be.ok;
           expect(reason.payload).to.be.null;
+          expect(reason.status).to.be.undefined;
         });
     });
 
@@ -901,6 +904,7 @@ describe('Unit | Mixin | ajax request', function() {
           .catch(function(reason) {
             expect(reason instanceof errorClass).to.be.ok;
             expect(reason.payload).to.not.be.undefined;
+            expect(reason.status).to.equal(status);
 
             const { errors } = reason.payload;
 

--- a/tests/unit/mixins/ajax-request-test.js
+++ b/tests/unit/mixins/ajax-request-test.js
@@ -885,7 +885,7 @@ describe('Unit | Mixin | ajax request', function() {
         .catch(function(reason) {
           expect(isTimeoutError(reason)).to.be.ok;
           expect(reason.payload).to.be.null;
-          expect(reason.status).to.be.undefined;
+          expect(reason.status).to.equal(-1);
         });
     });
 


### PR DESCRIPTION
As written in #275 it would make sense to expose the actual http status codes outside of the default error classes.
Only thing I can see which blocked the PR was this: https://github.com/ember-cli/ember-ajax/pull/275#pullrequestreview-32876092
So I tried to do everything of it. Only thing I couldn't achieve is to make it a switch statement. (I don't think it's possible, cause case expects only a value and not a expression and function calls are expressions. Right??? I'm really unsure but would like to know if I'm right or not)

Happy to work some more to get it merged 👀 