### PR TITLE
fix: make FastBoot test more reliable

### DIFF
--- a/fastboot-tests/helpers/server.js
+++ b/fastboot-tests/helpers/server.js
@@ -1,7 +1,15 @@
 var express = require('express');
 var posts = require('./fixtures').POSTS;
+var log = require('debug')('fastboot-tests:express-server');
 
 var app = express();
+
+app.use((req, res, next) => {
+  log(`${req.method}: ${req.originalUrl}`);
+
+  next();
+});
+
 app.use((req, res, next) => {
   res.header('Access-Control-Allow-Origin', '*');
   res.header('Access-Control-Allow-Methods', 'GET, OPTIONS');

--- a/fastboot-tests/index-test.js
+++ b/fastboot-tests/index-test.js
@@ -9,8 +9,8 @@ var POSTS = require('./helpers/fixtures').POSTS;
 describe('ember-ajax', function() {
   setupTest('fastboot' /*, options */);
 
-  beforeEach(function() {
-    this.server = expressApp.listen(3000);
+  beforeEach(function(done) {
+    this.server = expressApp.listen(3000, done);
   });
 
   afterEach(function() {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@commitlint/travis-cli": "^7.0.0",
     "broccoli-asset-rev": "^2.7.0",
     "chai": "^4.1.2",
+    "debug": "^3.1.0",
     "ember-cli": "~3.1.4",
     "ember-cli-chai": "^0.5.0",
     "ember-cli-dependency-checker": "^2.1.1",


### PR DESCRIPTION
I think that in some cases, the tests were being run before the Express
server had started. This should ensure that the express application
finished loading before Mocha begins executing the tests.