### PR TITLE
fix: skip instead of returning url when namespace is present in url

### DIFF
--- a/addon/mixins/ajax-request.ts
+++ b/addon/mixins/ajax-request.ts
@@ -482,18 +482,18 @@ export default Mixin.create({
 
     let namespace = options.namespace || get(this, 'namespace');
     if (namespace) {
-      // If the URL has already been constructed (presumably, by Ember Data), then we should just leave it alone
-      const hasNamespaceRegex = new RegExp(`^(/)?${stripSlashes(namespace)}/`);
-      if (hasNamespaceRegex.test(url)) {
-        return url;
-      }
       // If host is given then we need to strip leading slash too( as it will be added through join)
       if (host) {
         namespace = stripSlashes(namespace);
       } else if (endsWithSlash(namespace)) {
         namespace = removeTrailingSlash(namespace);
       }
-      urlParts.push(namespace);
+
+      // If the URL has already been constructed (presumably, by Ember Data), then we should just leave it alone
+      const hasNamespaceRegex = new RegExp(`^(/)?${stripSlashes(namespace)}/`);
+      if (!hasNamespaceRegex.test(url)) {
+        urlParts.push(namespace);
+      }
     }
 
     // *Only* remove a leading slash when there is host or namespace -- we need to maintain a trailing slash for

--- a/tests/unit/mixins/ajax-request-test.js
+++ b/tests/unit/mixins/ajax-request-test.js
@@ -227,6 +227,20 @@ describe('Unit | Mixin | ajax request', function() {
         );
       });
 
+      it('is set on the url containing namespace', function() {
+        const RequestWithHostAndNamespace = AjaxRequest.extend({
+          host: 'https://discuss.emberjs.com',
+          namespace: '/api/v1'
+        });
+        const service = new RequestWithHostAndNamespace();
+        const url = '/api/v1/users/me';
+        const ajaxoptions = service.options(url);
+
+        expect(ajaxoptions.url).to.equal(
+          'https://discuss.emberjs.com/api/v1/users/me'
+        );
+      });
+
       it('is set with the host address as `//` and url not starting with `/`', function() {
         const RequestWithHostAndNamespace = AjaxRequest.extend({
           host: '//'


### PR DESCRIPTION
When the namespace is present in the url, the host value being set is not taken into account. This PR fixes that issue. I have added a Test case for the scenario.
 
Let me know if anything else is required. 