### PR TITLE
Fix Node.js compatibility claim in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ This information is only relevant if you're looking to contribute to `ember-ajax
 
 ### Compatibility
 
+- Node.js 6 or above
 - Ember CLI v2.13 or above
 
 ### Installation

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@types/jquery": "^3.3.10"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "6.* || 8.* || >= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
`ember-ajax` requires and tests with Node.js 6+ but in `package.json` it says `4+`. This PR fixes that.