### PR TITLE
Always run tests in IE11 mode

### DIFF
--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -3,15 +3,9 @@
 const browsers = [
   'last 1 Chrome versions',
   'last 1 Firefox versions',
-  'last 1 Safari versions'
+  'last 1 Safari versions',
+  'ie 11'
 ];
-
-const isCI = !!process.env.CI;
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
 
 module.exports = {
   browsers


### PR DESCRIPTION
This would have made https://github.com/ember-cli/ember-ajax/issues/431 a lot more straight-forward to debug, as the issue seemed to only exist on CI and it took us a while to figure out why we did not see it locally.

/cc @rwjblue 