### PR TITLE
fix: types on public properties in ajax-request mixin

### DIFF
--- a/addon/mixins/ajax-request.ts
+++ b/addon/mixins/ajax-request.ts
@@ -214,25 +214,25 @@ export default Mixin.create({
    * @property {Headers} headers
    * @public
    */
-  headers: undefined,
+  headers: undefined as undefined | Headers,
 
   /**
    * @property {string} host
    * @public
    */
-  host: undefined,
+  host: undefined as undefined | string,
 
   /**
    * @property {string} namespace
    * @public
    */
-  namespace: undefined,
+  namespace: undefined as undefined | string,
 
   /**
    * @property {Matcher[]} trustedHosts
    * @public
    */
-  trustedHosts: undefined,
+  trustedHosts: undefined as undefined | Matcher[],
 
   /**
    * Make an AJAX request, ignoring the raw XHR object and dealing only with


### PR DESCRIPTION
Cast types of public properties initialized to `undefined` to `undefined | <type>` so that they can be overridden without type errors.