### PR TITLE
Resolve `ember-polyfills.deprecate-assign` deprecation warnings

### DIFF
--- a/addon/mixins/ajax-request.ts
+++ b/addon/mixins/ajax-request.ts
@@ -3,7 +3,6 @@ import EmberError from '@ember/error';
 import Mixin from '@ember/object/mixin';
 import { get } from '@ember/object';
 import { isEmpty } from '@ember/utils';
-import { assign } from '@ember/polyfills';
 import { join } from '@ember/runloop';
 import { warn, runInDebug } from '@ember/debug';
 import Ember from 'ember';
@@ -434,7 +433,7 @@ export default Mixin.create({
    */
   _getFullHeadersHash(headers?: Headers): Headers {
     const classHeaders = get(this, 'headers');
-    return assign({}, classHeaders!, headers!);
+    return { ...classHeaders!, ...headers! };
   },
 
   /**
@@ -442,7 +441,7 @@ export default Mixin.create({
    * service-level settings
    */
   options(url: string, options: AJAXOptions = {}): AJAXOptions {
-    options = assign({}, options);
+    options = { ...options };
     options.url = this._buildURL(url, options);
     options.type = options.type || 'GET';
     options.dataType = options.dataType || 'json';

--- a/addon/mixins/legacy/normalize-error-response.ts
+++ b/addon/mixins/legacy/normalize-error-response.ts
@@ -1,7 +1,6 @@
 import Mixin from '@ember/object/mixin';
 import { isArray } from '@ember/array';
 import { isNone } from '@ember/utils';
-import { assign } from '@ember/polyfills';
 
 import isString from '../../-private/utils/is-string';
 import { Headers } from '../../-private/types';
@@ -83,7 +82,7 @@ export default Mixin.create({
     if (isJsonApiErrorResponse(payload)) {
       return payload.errors.map(function(error) {
         if (isObject(error)) {
-          const ret = assign({}, error);
+          const ret = { ...error };
           ret.status = `${error.status}`;
           return ret;
         } else {

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,12 +1,11 @@
 import Application from '../../app';
 import config from '../../config/environment';
-import { assign } from '@ember/polyfills';
 import { run } from '@ember/runloop';
 
 export default function startApp(attrs) {
-  let attributes = assign({}, config.APP);
+  let attributes = Object.assign({}, config.APP);
   attributes.autoboot = true;
-  attributes = assign(attributes, attrs); // use defaults, but you can override;
+  attributes = Object.assign(attributes, attrs); // use defaults, but you can override;
 
   return run(() => {
     let application = Application.create(attributes);


### PR DESCRIPTION
Because the latter is deprecated in Ember 4.

cc @Turbo87 